### PR TITLE
Publish releases

### DIFF
--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,52 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish release
+
+on:
+  push:
+    tags:
+    - 'v*'
+
+jobs:
+
+  release:
+    name: Publish release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout the source
+      uses: actions/checkout@v2
+
+    - name: Setup Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.17
+
+    - name: Import GPG key
+      id: import_gpg_key
+      uses: hashicorp/ghaction-import-gpg@v2.1.0
+      env:
+        GPG_PRIVATE_KEY: ${{ secrets.RELEASER_GPG_PRIVATE_KEY }}
+        PASSPHRASE: ${{ secrets.RELEASER_GPG_PASSPHRASE }}
+
+    - name: Run releaser
+      uses: goreleaser/goreleaser-action@v2.8.0
+      with:
+        version: latest
+        args: release --rm-dist
+      env:
+        GPG_FINGERPRINT: ${{ steps.import_gpg_key.outputs.fingerprint }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 .terraform*
+/dist/
 terraform.tfstate*

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+builds:
+- env:
+  - CGO_ENABLED=0
+  mod_timestamp: '{{ .CommitTimestamp }}'
+  flags:
+  - -trimpath
+  goos:
+  - darwin
+  - linux
+  - windows
+  goarch:
+  - amd64
+  binary: '{{ .ProjectName }}_v{{ .Version }}'
+archives:
+- format: zip
+  name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
+checksum:
+  name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
+  algorithm: sha256
+signs:
+- artifacts: checksum
+  args:
+  - '--batch'
+  - '--local-user'
+  - '{{ .Env.GPG_FINGERPRINT }}'
+  - '--output'
+  - '${signature}'
+  - '--detach-sign'
+  - '${artifact}'
+release:
+  name_template: 'Release {{ .Version }}'
+changelog:
+  skip: true
+


### PR DESCRIPTION
This patch adds the GitHub workflow and GoRelease configuration needed
to publish releases of the provider according to the requirements of
_registry.terraform.io_.