### PR TITLE
Add machine types data source

### DIFF
--- a/examples/list_machine_types/README.md
+++ b/examples/list_machine_types/README.md
@@ -1,0 +1,5 @@
+# Machine types list example
+
+This example shows how to use the machine types data source to get a list of the
+supported machine types. To run it adjust the configuration of the provider in
+the `main.tf` file and then run the `terraform apply` command.

--- a/examples/list_machine_types/main.tf
+++ b/examples/list_machine_types/main.tf
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+terraform {
+  required_providers {
+    ocm = {
+      version = ">= 0.1"
+      source  = "openshift-online/ocm"
+    }
+  }
+}
+
+provider "ocm" {
+}
+
+data "ocm_machine_types" "all" {
+}
+
+output "machine_types" {
+  description = "Machine types"
+  value       = data.ocm_machine_types.all
+}

--- a/provider/cloud_providers_state.go
+++ b/provider/cloud_providers_state.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package provider
 
-type CloudProviderState struct {
-	ID          string `tfsdk:"id"`
-	Name        string `tfsdk:"name"`
-	DisplayName string `tfsdk:"display_name"`
+type CloudProvidersState struct {
+	Items []*CloudProviderState `tfsdk:"items"`
 }

--- a/provider/machine_type_state.go
+++ b/provider/machine_type_state.go
@@ -16,8 +16,10 @@ limitations under the License.
 
 package provider
 
-type CloudProviderState struct {
-	ID          string `tfsdk:"id"`
-	Name        string `tfsdk:"name"`
-	DisplayName string `tfsdk:"display_name"`
+type MachineTypeState struct {
+	CloudProvider string `tfsdk:"cloud_provider"`
+	ID            string `tfsdk:"id"`
+	Name          string `tfsdk:"name"`
+	CPU           int64  `tfsdk:"cpu"`
+	RAM           int64  `tfsdk:"ram"`
 }

--- a/provider/machine_types_data_source.go
+++ b/provider/machine_types_data_source.go
@@ -1,0 +1,197 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+type MachineTypesDataSourceType struct {
+}
+
+type MachineTypesDataSource struct {
+	logger     logging.Logger
+	collection *cmv1.MachineTypesClient
+}
+
+func (t *MachineTypesDataSourceType) GetSchema(ctx context.Context) (result tfsdk.Schema,
+	diags diag.Diagnostics) {
+	result = tfsdk.Schema{
+		Description: "List of cloud providers.",
+		Attributes: map[string]tfsdk.Attribute{
+			"items": {
+				Description: "Items of the list.",
+				Attributes: tfsdk.ListNestedAttributes(
+					map[string]tfsdk.Attribute{
+						"cloud_provider": {
+							Description: "Unique identifier of the " +
+								"cloud provider where the machine " +
+								"type is supported.",
+							Type:     types.StringType,
+							Computed: true,
+						},
+						"id": {
+							Description: "Unique identifier of the " +
+								"machine type.",
+							Type:     types.StringType,
+							Computed: true,
+						},
+						"name": {
+							Description: "Short name of the machine " +
+								"type.",
+							Type:     types.StringType,
+							Computed: true,
+						},
+						"cpu": {
+							Description: "Number of CPU cores.",
+							Type:        types.Int64Type,
+							Computed:    true,
+						},
+						"ram": {
+							Description: "Amount of RAM in bytes.",
+							Type:        types.Int64Type,
+							Computed:    true,
+						},
+					},
+					tfsdk.ListNestedAttributesOptions{},
+				),
+				Computed: true,
+			},
+		},
+	}
+	return
+}
+
+func (t *MachineTypesDataSourceType) NewDataSource(ctx context.Context,
+	p tfsdk.Provider) (result tfsdk.DataSource, diags diag.Diagnostics) {
+	// Cast the provider interface to the specific implementation:
+	parent := p.(*Provider)
+
+	// Get the collection of machine types:
+	collection := parent.connection.ClustersMgmt().V1().MachineTypes()
+
+	// Create the resource:
+	result = &MachineTypesDataSource{
+		logger:     parent.logger,
+		collection: collection,
+	}
+	return
+}
+
+func (s *MachineTypesDataSource) Read(ctx context.Context, request tfsdk.ReadDataSourceRequest,
+	response *tfsdk.ReadDataSourceResponse) {
+	// Fetch the complete list of machine types:
+	var listItems []*cmv1.MachineType
+	listSize := 10
+	listPage := 1
+	listRequest := s.collection.List().Size(listSize)
+	for {
+		listResponse, err := listRequest.SendContext(ctx)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't list machine types",
+				err.Error(),
+			)
+			return
+		}
+		if listItems == nil {
+			listItems = make([]*cmv1.MachineType, 0, listResponse.Total())
+		}
+		listResponse.Items().Each(func(listItem *cmv1.MachineType) bool {
+			listItems = append(listItems, listItem)
+			return true
+		})
+		if listResponse.Size() < listSize {
+			break
+		}
+		listPage++
+		listRequest.Page(listPage)
+	}
+
+	// Populate the state:
+	state := &MachineTypesState{
+		Items: make([]*MachineTypeState, len(listItems)),
+	}
+	for i, listItem := range listItems {
+		cpuObject := listItem.CPU()
+		cpuValue := cpuObject.Value()
+		cpuUnit := cpuObject.Unit()
+		switch cpuUnit {
+		case "vCPU":
+			// Nothing.
+		default:
+			response.Diagnostics.AddError(
+				"Unknown CPU unit",
+				fmt.Sprintf("Don't know how to convert CPU unit '%s'", cpuUnit),
+			)
+			return
+		}
+		ramObject := listItem.Memory()
+		ramValue := ramObject.Value()
+		ramUnit := ramObject.Unit()
+		switch strings.ToLower(ramUnit) {
+		case "b":
+			// Nothing.
+		case "kb":
+			ramValue *= math.Pow10(3)
+		case "mb":
+			ramValue *= math.Pow10(6)
+		case "gb":
+			ramValue *= math.Pow10(9)
+		case "tb":
+			ramValue *= math.Pow10(12)
+		case "pb":
+			ramValue *= math.Pow10(15)
+		case "kib":
+			ramValue *= math.Pow(2, 10)
+		case "mib":
+			ramValue *= math.Pow(2, 20)
+		case "gib":
+			ramValue *= math.Pow(2, 30)
+		case "tib":
+			ramValue *= math.Pow(2, 40)
+		case "pib":
+			ramValue *= math.Pow(2, 50)
+		default:
+			response.Diagnostics.AddError(
+				"Unknown RAM unit",
+				fmt.Sprintf("Don't know how to convert RAM unit '%s'", ramUnit),
+			)
+			return
+		}
+		state.Items[i] = &MachineTypeState{
+			CloudProvider: listItem.CloudProvider().ID(),
+			ID:            listItem.ID(),
+			Name:          listItem.Name(),
+			CPU:           int64(cpuValue),
+			RAM:           int64(ramValue),
+		}
+	}
+
+	// Save the state:
+	diags := response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}

--- a/provider/machine_types_state.go
+++ b/provider/machine_types_state.go
@@ -16,8 +16,6 @@ limitations under the License.
 
 package provider
 
-type CloudProviderState struct {
-	ID          string `tfsdk:"id"`
-	Name        string `tfsdk:"name"`
-	DisplayName string `tfsdk:"display_name"`
+type MachineTypesState struct {
+	Items []*MachineTypeState `tfsdk:"items"`
 }

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -219,6 +219,7 @@ func (p *Provider) GetDataSources(ctx context.Context) (result map[string]tfsdk.
 	diags diag.Diagnostics) {
 	result = map[string]tfsdk.DataSourceType{
 		"ocm_cloud_providers": &CloudProvidersDataSourceType{},
+		"ocm_machine_types":   &MachineTypesDataSourceType{},
 	}
 	return
 }

--- a/tests/machine_types_data_source_test.go
+++ b/tests/machine_types_data_source_test.go
@@ -1,0 +1,164 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"                         // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Machine types data source", func() {
+	var ctx context.Context
+	var server *Server
+	var ca string
+	var token string
+
+	BeforeEach(func() {
+		// Create a contet:
+		ctx = context.Background()
+
+		// Create an access token:
+		token = MakeTokenString("Bearer", 10*time.Minute)
+
+		// Start the server:
+		server, ca = MakeTCPTLSServer()
+	})
+
+	AfterEach(func() {
+		// Stop the server:
+		server.Close()
+
+		// Remove the server CA file:
+		err := os.Remove(ca)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can list machine types", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/machine_types"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 1,
+				  "total": 2,
+				  "items": [
+				    {
+				      "name": "custom-16-131072-ext - Memory Optimized",
+				      "category": "memory_optimized",
+				      "size": "large",
+				      "id": "custom-16-131072-ext",
+				      "memory": {
+				        "value": 137438953472,
+				        "unit": "B"
+				      },
+				      "cpu": {
+				        "value": 16,
+				        "unit": "vCPU"
+				      },
+				      "cloud_provider": {
+				        "id": "gcp"
+				      },
+				      "ccs_only": false,
+				      "generic_name": "highmem-16"
+				    },
+				    {
+				      "name": "c5.12xlarge - Compute optimized",
+				      "category": "compute_optimized",
+				      "size": "xxlarge",
+				      "id": "c5.12xlarge",
+				      "memory": {
+				        "value": 103079215104,
+				        "unit": "B"
+				      },
+				      "cpu": {
+				        "value": 48,
+				        "unit": "vCPU"
+				      },
+				      "cloud_provider": {
+				        "id": "aws"
+				      },
+				      "ccs_only": true,
+				      "generic_name": "highcpu-48"
+				    }
+				  ]
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/redhat/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				data "ocm_machine_types" "my_machines" {
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_machine_types", "my_machines")
+
+		// Check the GCP machine type:
+		gcpTypes, err := JQ(`.attributes.items[] | select(.cloud_provider == "gcp")`, resource)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(gcpTypes).To(HaveLen(1))
+		gcpType := gcpTypes[0]
+		Expect(gcpType).To(MatchJQ(".cloud_provider", "gcp"))
+		Expect(gcpType).To(MatchJQ(".id", "custom-16-131072-ext"))
+		Expect(gcpType).To(MatchJQ(".name", "custom-16-131072-ext - Memory Optimized"))
+		Expect(gcpType).To(MatchJQ(".cpu", 16.0))
+		Expect(gcpType).To(MatchJQ(".ram", 137438953472.0))
+
+		// Check the AWS machine type:
+		awsTypes, err := JQ(`.attributes.items[] | select(.cloud_provider == "aws")`, resource)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(awsTypes).To(HaveLen(1))
+		awsType := awsTypes[0]
+		Expect(awsType).To(MatchJQ(".cloud_provider", "aws"))
+		Expect(awsType).To(MatchJQ(".id", "c5.12xlarge"))
+		Expect(awsType).To(MatchJQ(".name", "c5.12xlarge - Compute optimized"))
+		Expect(awsType).To(MatchJQ(".cpu", 48.0))
+		Expect(awsType).To(MatchJQ(".ram", 103079215104.0))
+	})
+})


### PR DESCRIPTION
This patch adds a `ocm_machine_types` data source that can be used to
list the supported machine types.