### PR TITLE
Add `nodes.compute` and `nodes.compute_machine_type`

### DIFF
--- a/docs/resources/ocm_cluster.md
+++ b/docs/resources/ocm_cluster.md
@@ -15,20 +15,47 @@ OpenShift managed cluster.
 ### Required
 
 - **cloud_provider** (String) Cloud provider identifier, for example 'aws'.
+
 - **cloud_region** (String) Cloud region identifier, for example 'us-east-1'.
+
 - **name** (String) Name of the cluster.
 
 ### Optional
 
-- **multi_az** (Boolean) Indicates if the cluster should be deployed to multiple availability zones. Default value is 'false'.
+- **multi_az** (Boolean) Indicates if the cluster should be deployed to multiple
+  availability zones. Default value is 'false'.
+
+  Note a cluster that was created in a single availability zone can't be changed
+  to use multiple availability zones. If you change the value of this attribute
+  the cluster will be deleted and created again.
+
+- **nodes** (Attributes) Number and characteristis of nodes of the cluster. (see
+  [below for nested schema](#nestedatt--nodes))
+
 - **properties** (Map of String) User defined properties.
+
 - **wait** (Boolean) Wait till the cluster is ready.
 
 ### Read-Only
 
 - **api_url** (String) URL of the API server.
+
 - **console_url** (String) URL of the console.
+
 - **id** (String) Unique identifier of the cluster.
+
 - **state** (String) State of the cluster.
 
+<a id="nestedatt--nodes"></a>
+### Nested Schema for `nodes`
 
+Optional:
+
+- **compute** (Number) Number of compute nodes of the cluster.
+
+- **compute_machine_type** (String) Identifier of the machine type used by the
+  compute nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source
+  to find the possible values.
+
+  Note that the compute machine type of a cluster can't be changed. If you change
+  the value of this attribute the cluster will be deleted and created again.

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/itchyny/gojq v0.12.5
 	github.com/onsi/ginkgo v1.16.4
 	github.com/onsi/gomega v1.16.0
-	github.com/openshift-online/ocm-sdk-go v0.1.216
+	github.com/openshift-online/ocm-sdk-go v0.1.218
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -348,8 +348,8 @@ github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1y
 github.com/onsi/gomega v1.16.0 h1:6gjqkI8iiRHMvdccRJM8rVKjCWk6ZIm6FTm3ddIe4/c=
 github.com/onsi/gomega v1.16.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/openshift-online/ocm-sdk-go v0.1.216 h1:F6PudSxb3RCNUNo8KGKOGjI3uBD8AVwrtHlPIFrRfUI=
-github.com/openshift-online/ocm-sdk-go v0.1.216/go.mod h1:uDiBAEupl2F5rkTBFC4y4ZPEV/ku/fFEBHot6OkYL+I=
+github.com/openshift-online/ocm-sdk-go v0.1.218 h1:82Uc7uRlzY0fNlUVe+H9zbwQ0EVkr+K224oBFETfyHQ=
+github.com/openshift-online/ocm-sdk-go v0.1.218/go.mod h1:uDiBAEupl2F5rkTBFC4y4ZPEV/ku/fFEBHot6OkYL+I=
 github.com/opentracing-contrib/go-observer v0.0.0-20170622124052-a52f23424492/go.mod h1:Ngi6UdF0k5OKD5t5wlmGhe/EDKPoUM3BXZSSfIuJbis=
 github.com/opentracing/basictracer-go v1.0.0/go.mod h1:QfBfYuafItcjQuMwinw9GhYKwFXS9KnPs5lxoYwgW74=
 github.com/opentracing/opentracing-go v1.0.2/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/provider/cluster_state.go
+++ b/provider/cluster_state.go
@@ -21,14 +21,20 @@ import (
 )
 
 type ClusterState struct {
-	ID            types.String `tfsdk:"id"`
-	Name          types.String `tfsdk:"name"`
-	CloudProvider types.String `tfsdk:"cloud_provider"`
-	CloudRegion   types.String `tfsdk:"cloud_region"`
-	MultiAZ       types.Bool   `tfsdk:"multi_az"`
-	Properties    types.Map    `tfsdk:"properties"`
-	APIURL        types.String `tfsdk:"api_url"`
-	ConsoleURL    types.String `tfsdk:"console_url"`
-	State         types.String `tfsdk:"state"`
-	Wait          types.Bool   `tfsdk:"wait"`
+	APIURL        types.String      `tfsdk:"api_url"`
+	CloudProvider types.String      `tfsdk:"cloud_provider"`
+	CloudRegion   types.String      `tfsdk:"cloud_region"`
+	ConsoleURL    types.String      `tfsdk:"console_url"`
+	ID            types.String      `tfsdk:"id"`
+	MultiAZ       types.Bool        `tfsdk:"multi_az"`
+	Name          types.String      `tfsdk:"name"`
+	Nodes         ClusterNodesState `tfsdk:"nodes"`
+	Properties    types.Map         `tfsdk:"properties"`
+	State         types.String      `tfsdk:"state"`
+	Wait          types.Bool        `tfsdk:"wait"`
+}
+
+type ClusterNodesState struct {
+	Compute            types.Int64  `tfsdk:"compute"`
+	ComputeMachineType types.String `tfsdk:"compute_machine_type"`
 }

--- a/provider/helpers.go
+++ b/provider/helpers.go
@@ -1,0 +1,57 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+// shouldPatchInt changed checks if the change between the given state and plan requires sending a
+// patch request to the server. If it does it returns the value to add to the patch.
+func shouldPatchInt(state, plan types.Int64) (value int64, ok bool) {
+	if plan.Unknown || plan.Null {
+		return
+	}
+	if state.Unknown || state.Null {
+		value = plan.Value
+		ok = true
+		return
+	}
+	if plan.Value != state.Value {
+		value = plan.Value
+		ok = true
+	}
+	return
+}
+
+// shouldPatchString changed checks if the change between the given state and plan requires sending
+// a patch request to the server. If it does it returns the value to add to the patch.
+func shouldPatchString(state, plan types.String) (value string, ok bool) {
+	if plan.Unknown || plan.Null {
+		return
+	}
+	if state.Unknown || state.Null {
+		value = plan.Value
+		ok = true
+		return
+	}
+	if plan.Value != state.Value {
+		value = plan.Value
+		ok = true
+	}
+	return
+}

--- a/tests/cluster_resource_test.go
+++ b/tests/cluster_resource_test.go
@@ -70,6 +70,13 @@ var _ = Describe("Cluster creation", func() {
 				  "region": {
 				    "kind": "CloudRegion",
 				    "id": "us-west-1"
+				  },
+				  "nodes": {
+				    "compute": 10,
+				    "compute_machine_type": {
+				      "kind": "MachineType",
+				      "id": "r5.xlarge"
+				    }
 				  }
 				}`),
 				RespondWithJSON(http.StatusCreated, `{
@@ -88,6 +95,12 @@ var _ = Describe("Cluster creation", func() {
 				  },
 				  "console": {
 				    "url": "https://my-console.example.com"
+				  },
+				  "nodes": {
+				    "compute": 10,
+				    "compute_machine_type": {
+				      "id": "r5.xlarge"
+				    }
 				  },
 				  "state": "ready"
 				}`),
@@ -116,6 +129,10 @@ var _ = Describe("Cluster creation", func() {
 				  name           = "my-cluster"
 				  cloud_provider = "aws"
 				  cloud_region   = "us-west-1"
+				  nodes          = {
+					  compute = 10
+					  compute_machine_type = "r5.xlarge"
+				  }
 				}
 				`,
 				"URL", server.URL(),
@@ -129,6 +146,8 @@ var _ = Describe("Cluster creation", func() {
 		resource := result.Resource("ocm_cluster", "my_cluster")
 		Expect(resource).To(MatchJQ(".attributes.api_url", "https://my-api.example.com"))
 		Expect(resource).To(MatchJQ(".attributes.console_url", "https://my-console.example.com"))
+		Expect(resource).To(MatchJQ(".attributes.nodes.compute", 10.0))
+		Expect(resource).To(MatchJQ(".attributes.nodes.compute_machine_type", "r5.xlarge"))
 	})
 
 	It("Fails if the cluster already exists", func() {


### PR DESCRIPTION
This patch adds to the `ocm_cluster` resource support for the
`nodes.compute` and `nodes.compute_machine_type` attributes.