### PR TITLE
Don't nest compute nodes and machine types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ build:
 	if [[ "$${platform}" =~ ^windows_.*$$ ]]; then \
 	  extension=".exe"; \
 	fi; \
-	dir=".terraform.d/plugins/localhost/redhat/ocm/$(version)/$${platform}"; \
+	dir=".terraform.d/plugins/localhost/openshift-online/ocm/$(version)/$${platform}"; \
 	file="terraform-provider-ocm$${extension}"; \
 	mkdir -p "$${dir}"; \
 	go build -ldflags="$(ldflags)" -o "$${dir}/$${file}"

--- a/docs/resources/ocm_cluster.md
+++ b/docs/resources/ocm_cluster.md
@@ -22,15 +22,21 @@ OpenShift managed cluster.
 
 ### Optional
 
+- **compute_nodes** (Number) Number of compute nodes of the cluster.
+
+- **compute_machine_type** (String) Identifier of the machine type used by the
+  compute nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source
+  to find the possible values.
+
+  Note that the compute machine type of a cluster can't be changed. If you change
+  the value of this attribute the cluster will be deleted and created again.
+
 - **multi_az** (Boolean) Indicates if the cluster should be deployed to multiple
   availability zones. Default value is 'false'.
 
   Note a cluster that was created in a single availability zone can't be changed
   to use multiple availability zones. If you change the value of this attribute
   the cluster will be deleted and created again.
-
-- **nodes** (Attributes) Number and characteristis of nodes of the cluster. (see
-  [below for nested schema](#nestedatt--nodes))
 
 - **properties** (Map of String) User defined properties.
 
@@ -45,17 +51,3 @@ OpenShift managed cluster.
 - **id** (String) Unique identifier of the cluster.
 
 - **state** (String) State of the cluster.
-
-<a id="nestedatt--nodes"></a>
-### Nested Schema for `nodes`
-
-Optional:
-
-- **compute** (Number) Number of compute nodes of the cluster.
-
-- **compute_machine_type** (String) Identifier of the machine type used by the
-  compute nodes, for example `r5.xlarge`. Use the `ocm_machine_types` data source
-  to find the possible values.
-
-  Note that the compute machine type of a cluster can't be changed. If you change
-  the value of this attribute the cluster will be deleted and created again.

--- a/examples/create_cluster/main.tf
+++ b/examples/create_cluster/main.tf
@@ -41,19 +41,3 @@ resource "ocm_identity_provider" "my_htpasswd" {
     password = "my-password"
   }
 }
-
-resource "ocm_identity_provider" "my_ldap" {
-  cluster_id = ocm_cluster.my_cluster.id
-  name       = "my-ldap"
-  ldap = {
-    bind_dn       = "my-bind-dn"
-    bind_password = "my-bind-password"
-    url           = "https://my-server.com"
-    attributes = {
-      id                 = ["my-id"]
-      email              = ["my-email"]
-      name               = ["my-name"]
-      preferred_username = ["my-preferred-username"]
-    }
-  }
-}

--- a/provider/cluster_state.go
+++ b/provider/cluster_state.go
@@ -21,20 +21,16 @@ import (
 )
 
 type ClusterState struct {
-	APIURL        types.String      `tfsdk:"api_url"`
-	CloudProvider types.String      `tfsdk:"cloud_provider"`
-	CloudRegion   types.String      `tfsdk:"cloud_region"`
-	ConsoleURL    types.String      `tfsdk:"console_url"`
-	ID            types.String      `tfsdk:"id"`
-	MultiAZ       types.Bool        `tfsdk:"multi_az"`
-	Name          types.String      `tfsdk:"name"`
-	Nodes         ClusterNodesState `tfsdk:"nodes"`
-	Properties    types.Map         `tfsdk:"properties"`
-	State         types.String      `tfsdk:"state"`
-	Wait          types.Bool        `tfsdk:"wait"`
-}
-
-type ClusterNodesState struct {
-	Compute            types.Int64  `tfsdk:"compute"`
-	ComputeMachineType types.String `tfsdk:"compute_machine_type"`
+	APIURL             types.String      `tfsdk:"api_url"`
+	CloudProvider      types.String      `tfsdk:"cloud_provider"`
+	CloudRegion        types.String      `tfsdk:"cloud_region"`
+	ComputeMachineType types.String      `tfsdk:"compute_machine_type"`
+	ComputeNodes       types.Int64       `tfsdk:"compute_nodes"`
+	ConsoleURL         types.String      `tfsdk:"console_url"`
+	ID                 types.String      `tfsdk:"id"`
+	MultiAZ            types.Bool        `tfsdk:"multi_az"`
+	Name               types.String      `tfsdk:"name"`
+	Properties         types.Map         `tfsdk:"properties"`
+	State              types.String      `tfsdk:"state"`
+	Wait               types.Bool        `tfsdk:"wait"`
 }

--- a/tests/cluster_resource_test.go
+++ b/tests/cluster_resource_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Cluster creation", func() {
 				terraform {
 				  required_providers {
 				    ocm = {
-				      source = "localhost/redhat/ocm"
+				      source = "localhost/openshift-online/ocm"
 				    }
 				  }
 				}
@@ -182,7 +182,7 @@ var _ = Describe("Cluster creation", func() {
 				terraform {
 				  required_providers {
 				    ocm = {
-				      source = "localhost/redhat/ocm"
+				      source = "localhost/openshift-online/ocm"
 				    }
 				  }
 				}

--- a/tests/cluster_resource_test.go
+++ b/tests/cluster_resource_test.go
@@ -35,6 +35,34 @@ var _ = Describe("Cluster creation", func() {
 	var ca string
 	var token string
 
+	// This is the cluster that will be returned by the server when asked to create or retrieve
+	// a cluster.
+	const template = `{
+	  "id": "123",
+	  "name": "my-cluster",
+	  "cloud_provider": {
+	    "id": "aws"
+	  },
+	  "region": {
+	    "id": "us-west-1"
+	  },
+	  "multi_az": false,
+	  "properties": {},
+	  "api": {
+	    "url": "https://my-api.example.com"
+	  },
+	  "console": {
+	    "url": "https://my-console.example.com"
+	  },
+	  "nodes": {
+	    "compute": 3,
+	    "compute_machine_type": {
+	      "id": "r5.xlarge"
+	    }
+	  },
+	  "state": "ready"
+	}`
+
 	BeforeEach(func() {
 		// Create a contet:
 		ctx = context.Background()
@@ -55,7 +83,7 @@ var _ = Describe("Cluster creation", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Succeeds if the cluster doesn't exist", func() {
+	It("Creates basic cluster", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
@@ -70,40 +98,9 @@ var _ = Describe("Cluster creation", func() {
 				  "region": {
 				    "kind": "CloudRegion",
 				    "id": "us-west-1"
-				  },
-				  "nodes": {
-				    "compute": 10,
-				    "compute_machine_type": {
-				      "kind": "MachineType",
-				      "id": "r5.xlarge"
-				    }
 				  }
 				}`),
-				RespondWithJSON(http.StatusCreated, `{
-				  "id": "123",
-				  "name": "my-cluster",
-				  "cloud_provider": {
-				    "id": "aws"
-				  },
-				  "region": {
-				    "id": "us-west-1"
-				  },
-				  "multi_az": false,
-				  "properties": {},
-				  "api": {
-				    "url": "https://my-api.example.com"
-				  },
-				  "console": {
-				    "url": "https://my-console.example.com"
-				  },
-				  "nodes": {
-				    "compute": 10,
-				    "compute_machine_type": {
-				      "id": "r5.xlarge"
-				    }
-				  },
-				  "state": "ready"
-				}`),
+				RespondWithJSON(http.StatusCreated, template),
 			),
 		)
 
@@ -129,10 +126,47 @@ var _ = Describe("Cluster creation", func() {
 				  name           = "my-cluster"
 				  cloud_provider = "aws"
 				  cloud_region   = "us-west-1"
-				  nodes          = {
-					  compute = 10
-					  compute_machine_type = "r5.xlarge"
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+	})
+
+	It("Saves API and console URLs to the state", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				RespondWithJSON(http.StatusCreated, template),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
 				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				resource "ocm_cluster" "my_cluster" {
+				  name           = "my-cluster"
+				  cloud_provider = "aws"
+				  cloud_region   = "us-west-1"
 				}
 				`,
 				"URL", server.URL(),
@@ -146,11 +180,54 @@ var _ = Describe("Cluster creation", func() {
 		resource := result.Resource("ocm_cluster", "my_cluster")
 		Expect(resource).To(MatchJQ(".attributes.api_url", "https://my-api.example.com"))
 		Expect(resource).To(MatchJQ(".attributes.console_url", "https://my-console.example.com"))
-		Expect(resource).To(MatchJQ(".attributes.nodes.compute", 10.0))
-		Expect(resource).To(MatchJQ(".attributes.nodes.compute_machine_type", "r5.xlarge"))
 	})
 
-	It("Fails if the cluster already exists", func() {
+	It("Saves console URL to the state", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				RespondWithJSON(http.StatusCreated, template),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				resource "ocm_cluster" "my_cluster" {
+				  name           = "my-cluster"
+				  cloud_provider = "aws"
+				  cloud_region   = "us-west-1"
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_cluster", "my_cluster")
+		Expect(resource).To(MatchJQ(".attributes.api_url", "https://my-api.example.com"))
+	})
+
+	It("Sets compute nodes and machine type", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
@@ -165,8 +242,63 @@ var _ = Describe("Cluster creation", func() {
 				  "region": {
 				    "kind": "CloudRegion",
 				    "id": "us-west-1"
+				  },
+				  "nodes": {
+				    "compute": 3,
+				    "compute_machine_type": {
+				      "kind": "MachineType",
+				      "id": "r5.xlarge"
+				    }
 				  }
 				}`),
+				RespondWithJSON(http.StatusCreated, template),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				resource "ocm_cluster" "my_cluster" {
+				  name                 = "my-cluster"
+				  cloud_provider       = "aws"
+				  cloud_region         = "us-west-1"
+				  compute_nodes        = 3
+				  compute_machine_type = "r5.xlarge"
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_cluster", "my_cluster")
+		Expect(resource).To(MatchJQ(".attributes.compute_nodes", 3.0))
+		Expect(resource).To(MatchJQ(".attributes.compute_machine_type", "r5.xlarge"))
+	})
+
+	It("Fails if the cluster already exists", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
 				RespondWithJSON(http.StatusBadRequest, `{
 				  "id": "400",
 				  "code": "CLUSTERS-MGMT-400",

--- a/tests/identity_provider_resource_test.go
+++ b/tests/identity_provider_resource_test.go
@@ -103,7 +103,7 @@ var _ = Describe("Identity provider creation", func() {
 				terraform {
 				  required_providers {
 				    ocm = {
-				      source = "localhost/redhat/ocm"
+				      source = "localhost/openshift-online/ocm"
 				    }
 				  }
 				}
@@ -184,7 +184,7 @@ var _ = Describe("Identity provider creation", func() {
 				terraform {
 				  required_providers {
 				    ocm = {
-				      source = "localhost/redhat/ocm"
+				      source = "localhost/openshift-online/ocm"
 				    }
 				  }
 				}

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -37,7 +37,7 @@ var _ = Describe("Init", func() {
 				terraform {
 				  required_providers {
 				    ocm = {
-				      source  = "localhost/redhat/ocm"
+				      source  = "localhost/openshift-online/ocm"
 				    }
 				  }
 				}

--- a/tests/machine_types_data_source_test.go
+++ b/tests/machine_types_data_source_test.go
@@ -115,7 +115,7 @@ var _ = Describe("Machine types data source", func() {
 				terraform {
 				  required_providers {
 				    ocm = {
-				      source = "localhost/redhat/ocm"
+				      source = "localhost/openshift-online/ocm"
 				    }
 				  }
 				}


### PR DESCRIPTION
Currently the compute nodes and machine types are nested attributes like
this:

```hcl
nodes = {
  compute      = 10
  machine_type = "r5.xlarge"
}
```

But unfortunately this nesting produces an error that seems impossible
to solve when the `nodes` attribute isn't used, something like this:

```
Error: Value Conversion Error

  with ocm_cluster.my_cluster,
  on main.tf line 16, in resource "ocm_cluster" "my_cluster":
  16: resource "ocm_cluster" "my_cluster" {

An unexpected error was encountered trying to build a value. This is always
an error in the provider. Please report the following to the provider
developer:

unhandled null value
```

To avoid that this patch changes the attributes so that they aren't
nested:

```hcl
compute_nodes        = 10
compute_machine_type = "r5.xlarge"
```