### PR TITLE
Add machine pool resource

### DIFF
--- a/docs/resources/ocm_machine_pool.md
+++ b/docs/resources/ocm_machine_pool.md
@@ -1,0 +1,28 @@
+---
+page_title: "ocm_machine_pool Resource"
+subcategory: ""
+description: |-
+  Machine pool.
+---
+
+# ocm_machine_pool (Resource)
+
+Machine pool.
+
+## Schema
+
+### Required
+
+- **cluster_id** (String) Identifier of the cluster.
+
+- **machine_type** (String) Identifier of the machine type used by the nodes,
+  for example `r5.xlarge`. Use the `ocm_machine_types` data source to find the
+  possible values.
+
+- **name** (String) Name of the machine pool.
+
+- **replicas** (Number) The number of machines of the pool
+
+### Read-Only
+
+- **id** (String) Unique identifier of the machine pool.

--- a/examples/create_cluster/main.tf
+++ b/examples/create_cluster/main.tf
@@ -30,14 +30,25 @@ resource "ocm_cluster" "my_cluster" {
   name           = "my-cluster"
   cloud_provider = "aws"
   cloud_region   = "us-east-1"
-  multi_az       = true
+  compute_nodes  = 10
+  properties = {
+    department  = "accounting"
+    application = "billing"
+  }
 }
 
-resource "ocm_identity_provider" "my_htpasswd" {
+resource "ocm_identity_provider" "my_idp" {
   cluster_id = ocm_cluster.my_cluster.id
-  name       = "my-htpasswd"
+  name       = "my-idp"
   htpasswd = {
-    username = "my-user"
-    password = "my-password"
+    username = "admin"
+    password = "redhat123"
   }
+}
+
+resource "ocm_machine_pool" "my_pool" {
+  cluster_id   = ocm_cluster.my_cluster.id
+  name         = "my-pool"
+  machine_type = "r5.xlarge"
+  replicas     = 5
 }

--- a/provider/cluster_state.go
+++ b/provider/cluster_state.go
@@ -21,16 +21,16 @@ import (
 )
 
 type ClusterState struct {
-	APIURL             types.String      `tfsdk:"api_url"`
-	CloudProvider      types.String      `tfsdk:"cloud_provider"`
-	CloudRegion        types.String      `tfsdk:"cloud_region"`
-	ComputeMachineType types.String      `tfsdk:"compute_machine_type"`
-	ComputeNodes       types.Int64       `tfsdk:"compute_nodes"`
-	ConsoleURL         types.String      `tfsdk:"console_url"`
-	ID                 types.String      `tfsdk:"id"`
-	MultiAZ            types.Bool        `tfsdk:"multi_az"`
-	Name               types.String      `tfsdk:"name"`
-	Properties         types.Map         `tfsdk:"properties"`
-	State              types.String      `tfsdk:"state"`
-	Wait               types.Bool        `tfsdk:"wait"`
+	APIURL             types.String `tfsdk:"api_url"`
+	CloudProvider      types.String `tfsdk:"cloud_provider"`
+	CloudRegion        types.String `tfsdk:"cloud_region"`
+	ComputeMachineType types.String `tfsdk:"compute_machine_type"`
+	ComputeNodes       types.Int64  `tfsdk:"compute_nodes"`
+	ConsoleURL         types.String `tfsdk:"console_url"`
+	ID                 types.String `tfsdk:"id"`
+	MultiAZ            types.Bool   `tfsdk:"multi_az"`
+	Name               types.String `tfsdk:"name"`
+	Properties         types.Map    `tfsdk:"properties"`
+	State              types.String `tfsdk:"state"`
+	Wait               types.Bool   `tfsdk:"wait"`
 }

--- a/provider/machine_pool_resource.go
+++ b/provider/machine_pool_resource.go
@@ -1,0 +1,254 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+type MachinePoolResourceType struct {
+}
+
+type MachinePoolResource struct {
+	logger     logging.Logger
+	collection *cmv1.ClustersClient
+}
+
+func (t *MachinePoolResourceType) GetSchema(ctx context.Context) (result tfsdk.Schema,
+	diags diag.Diagnostics) {
+	result = tfsdk.Schema{
+		Description: "Machine pool.",
+		Attributes: map[string]tfsdk.Attribute{
+			"cluster_id": {
+				Description: "Identifier of the cluster.",
+				Type:        types.StringType,
+				Required:    true,
+			},
+			"id": {
+				Description: "Unique identifier of the machine pool.",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+			"name": {
+				Description: "Name of the machine pool.",
+				Type:        types.StringType,
+				Required:    true,
+			},
+			"machine_type": {
+				Description: "Identifier of the machine type used by the nodes, " +
+					"for example `r5.xlarge`. Use the `ocm_machine_types` data " +
+					"source to find the possible values.",
+				Type:     types.StringType,
+				Required: true,
+			},
+			"replicas": {
+				Description: "The number of machines of the pool",
+				Type:        types.Int64Type,
+				Required:    true,
+			},
+		},
+	}
+	return
+}
+
+func (t *MachinePoolResourceType) NewResource(ctx context.Context,
+	p tfsdk.Provider) (result tfsdk.Resource, diags diag.Diagnostics) {
+	// Cast the provider interface to the specific implementation: use it directly when needed.
+	parent := p.(*Provider)
+
+	// Get the collection of clusters:
+	collection := parent.connection.ClustersMgmt().V1().Clusters()
+
+	// Create the resource:
+	result = &MachinePoolResource{
+		logger:     parent.logger,
+		collection: collection,
+	}
+
+	return
+}
+
+func (r *MachinePoolResource) Create(ctx context.Context,
+	request tfsdk.CreateResourceRequest, response *tfsdk.CreateResourceResponse) {
+	// Get the plan:
+	state := &MachinePoolState{}
+	diags := request.Plan.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Wait till the cluster is ready:
+	resource := r.collection.Cluster(state.ClusterID.Value)
+	pollCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
+	defer cancel()
+	_, err := resource.Poll().
+		Interval(30 * time.Second).
+		Predicate(func(get *cmv1.ClusterGetResponse) bool {
+			return get.Body().State() == cmv1.ClusterStateReady
+		}).
+		StartContext(pollCtx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't poll cluster state",
+			fmt.Sprintf(
+				"Can't poll state of cluster with identifier '%s': %v",
+				state.ClusterID.Value, err,
+			),
+		)
+		return
+	}
+
+	// Create the machine pool:
+	builder := cmv1.NewMachinePool()
+	builder.ID(state.Name.Value)
+	builder.InstanceType(state.MachineType.Value)
+	builder.Replicas(int(state.Replicas.Value))
+	object, err := builder.Build()
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't build machine pool",
+			fmt.Sprintf(
+				"Can't build machine pool for cluster '%s': %v",
+				state.ClusterID.Value, err,
+			),
+		)
+		return
+	}
+	collection := resource.MachinePools()
+	add, err := collection.Add().Body(object).SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't create machine pool",
+			fmt.Sprintf(
+				"Can't create machine pool for cluster '%s': %v",
+				state.ClusterID.Value, err,
+			),
+		)
+		return
+	}
+	object = add.Body()
+
+	// Save the state:
+	r.populateState(object, state)
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}
+
+func (r *MachinePoolResource) Read(ctx context.Context, request tfsdk.ReadResourceRequest,
+	response *tfsdk.ReadResourceResponse) {
+	// Get the current state:
+	state := &MachinePoolState{}
+	diags := request.State.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Find the identity provider:
+	resource := r.collection.Cluster(state.ClusterID.Value).
+		MachinePools().
+		MachinePool(state.ID.Value)
+	get, err := resource.Get().SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't find machine pool",
+			fmt.Sprintf(
+				"Can't find machine pool with identifier '%s' for "+
+					"cluster '%s': %v",
+				state.ID.Value, state.ClusterID.Value, err,
+			),
+		)
+		return
+	}
+	object := get.Body()
+
+	// Save the state:
+	r.populateState(object, state)
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}
+
+func (r *MachinePoolResource) Update(ctx context.Context, request tfsdk.UpdateResourceRequest,
+	response *tfsdk.UpdateResourceResponse) {
+}
+
+func (r *MachinePoolResource) Delete(ctx context.Context, request tfsdk.DeleteResourceRequest,
+	response *tfsdk.DeleteResourceResponse) {
+	// Get the state:
+	state := &MachinePoolState{}
+	diags := request.State.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Send the request to delete the machine pool:
+	resource := r.collection.Cluster(state.ClusterID.Value).
+		MachinePools().
+		MachinePool(state.ID.Value)
+	_, err := resource.Delete().SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't delete machine pool",
+			fmt.Sprintf(
+				"Can't delete machine pool with identifier '%s' for "+
+					"cluster '%s': %v",
+				state.ID.Value, state.ClusterID.Value, err,
+			),
+		)
+		return
+	}
+
+	// Remove the state:
+	response.State.RemoveResource(ctx)
+}
+
+func (r *MachinePoolResource) ImportState(ctx context.Context, request tfsdk.ImportResourceStateRequest,
+	response *tfsdk.ImportResourceStateResponse) {
+	tfsdk.ResourceImportStatePassthroughID(
+		ctx,
+		tftypes.NewAttributePath().WithAttributeName("id"),
+		request,
+		response,
+	)
+}
+
+// populateState copies the data from the API object to the Terraform state.
+func (r *MachinePoolResource) populateState(object *cmv1.MachinePool, state *MachinePoolState) {
+	state.ID = types.String{
+		Value: object.ID(),
+	}
+	state.Name = types.String{
+		Value: object.ID(),
+	}
+	state.MachineType = types.String{
+		Value: object.InstanceType(),
+	}
+	state.Replicas = types.Int64{
+		Value: int64(object.Replicas()),
+	}
+}

--- a/provider/machine_pool_state.go
+++ b/provider/machine_pool_state.go
@@ -1,0 +1,29 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type MachinePoolState struct {
+	ClusterID   types.String `tfsdk:"cluster_id"`
+	ID          types.String `tfsdk:"id"`
+	MachineType types.String `tfsdk:"machine_type"`
+	Name        types.String `tfsdk:"name"`
+	Replicas    types.Int64  `tfsdk:"replicas"`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -210,6 +210,7 @@ func (p *Provider) GetResources(ctx context.Context) (result map[string]tfsdk.Re
 	result = map[string]tfsdk.ResourceType{
 		"ocm_cluster":           &ClusterResourceType{},
 		"ocm_identity_provider": &IdentityProviderResourceType{},
+		"ocm_machine_pool":      &MachinePoolResourceType{},
 	}
 	return
 }

--- a/tests/machine_pool_resource_test.go
+++ b/tests/machine_pool_resource_test.go
@@ -1,0 +1,134 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"                         // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Machine pool creation", func() {
+	var ctx context.Context
+	var server *Server
+	var ca string
+	var token string
+
+	BeforeEach(func() {
+		// Create a contet:
+		ctx = context.Background()
+
+		// Create an access token:
+		token = MakeTokenString("Bearer", 10*time.Minute)
+
+		// Start the server:
+		server, ca = MakeTCPTLSServer()
+
+		// The first thing that the provider will do for any operation on identity providers
+		// is check that the cluster is ready, so we always need to prepare the server to
+		// respond to that:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, `{
+				  "id": "123",
+				  "name": "my-cluster",
+				  "state": "ready"
+				}`),
+			),
+		)
+	})
+
+	AfterEach(func() {
+		// Stop the server:
+		server.Close()
+
+		// Remove the server CA file:
+		err := os.Remove(ca)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can create machine pool", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(
+					http.MethodPost,
+					"/api/clusters_mgmt/v1/clusters/123/machine_pools",
+				),
+				VerifyJSON(`{
+				  "kind": "MachinePool",
+				  "id": "my-pool",
+				  "instance_type": "r5.xlarge",
+				  "replicas": 10
+				}`),
+				RespondWithJSON(http.StatusOK, `{
+				  "id": "my-pool",
+				  "instance_type": "r5.xlarge",
+				  "replicas": 10
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				resource "ocm_machine_pool" "my_pool" {
+				  cluster_id   = "123"
+				  name         = "my-pool"
+				  machine_type = "r5.xlarge"
+				  replicas     = 10
+				}
+					`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_machine_pool", "my_pool")
+		Expect(resource).To(MatchJQ(".attributes.cluster_id", "123"))
+		Expect(resource).To(MatchJQ(".attributes.id", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.name", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.machine_type", "r5.xlarge"))
+		Expect(resource).To(MatchJQ(".attributes.replicas", 10.0))
+	})
+})


### PR DESCRIPTION
This patch adds a new `ocm_machine_pool` resource that can be used to
create and manage machine pools. For example, to create a machine pool
with five `r5.xlarge` machines:

```hcl
resource "ocm_machine_pool" "my_pool" {
  cluster_id   = ocm_cluster.my_cluster.id
  name         = "my-pool"
  machine_type = "r5.xlarge"
  replicas     = 5
}
```