### PR TITLE
Add groups data source

### DIFF
--- a/docs/data-sources/ocm_groups.md
+++ b/docs/data-sources/ocm_groups.md
@@ -1,0 +1,36 @@
+---
+page_title: "ocm_groups Data Source"
+subcategory: ""
+description: |-
+  List of groups.
+---
+
+# ocm_groups (Data Source)
+
+Lists the groups of users of a cluster.
+
+Currently there is only one group named `dedicated-admins` is supported, so
+this data source will always return exactly one item.
+
+## Schema
+
+### Required
+
+- **cluster** (String) Identifier of the cluster.
+
+### Read-Only
+
+- **items** (Attributes List) Items of the list. (see [below for nested schema](#nestedatt--items))
+
+<a id="nestedatt--items"></a>
+### Nested Schema for `items`
+
+Read-Only:
+
+- **id** (String) Unique identifier of the group. This is what should be used
+  when referencing the group from other places, for example in the `group`
+  attribute of the user resource.
+
+- **name** (String) Short name of the group for example `dedicated-admins`.
+
+

--- a/provider/group_state.go
+++ b/provider/group_state.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type GroupState struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}

--- a/provider/groups_data_source.go
+++ b/provider/groups_data_source.go
@@ -1,0 +1,149 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+type GroupsDataSourceType struct {
+}
+
+type GroupsDataSource struct {
+	logger     logging.Logger
+	collection *cmv1.ClustersClient
+}
+
+func (t *GroupsDataSourceType) GetSchema(ctx context.Context) (result tfsdk.Schema,
+	diags diag.Diagnostics) {
+	result = tfsdk.Schema{
+		Description: "List of groups.",
+		Attributes: map[string]tfsdk.Attribute{
+			"cluster": {
+				Description: "Identifier of the cluster.",
+				Type:        types.StringType,
+				Required:    true,
+			},
+			"items": {
+				Description: "Items of the list.",
+				Attributes:  t.itemSchema(),
+				Computed:    true,
+			},
+		},
+	}
+	return
+}
+
+func (t *GroupsDataSourceType) itemSchema() tfsdk.NestedAttributes {
+	return tfsdk.ListNestedAttributes(
+		map[string]tfsdk.Attribute{
+			"id": {
+				Description: "Unique identifier of the group. This is what " +
+					"should be used when referencing the group from other " +
+					"places, for example in the 'group' attribute of the " +
+					"user resource.",
+				Type:     types.StringType,
+				Computed: true,
+			},
+			"name": {
+				Description: "Short name of the group for example " +
+					"'dedicated-admins'.",
+				Type:     types.StringType,
+				Computed: true,
+			},
+		},
+		tfsdk.ListNestedAttributesOptions{},
+	)
+}
+
+func (t *GroupsDataSourceType) NewDataSource(ctx context.Context,
+	p tfsdk.Provider) (result tfsdk.DataSource, diags diag.Diagnostics) {
+	// Cast the provider interface to the specific implementation:
+	parent := p.(*Provider)
+
+	// Get the collection of clusters:
+	collection := parent.connection.ClustersMgmt().V1().Clusters()
+
+	// Create the resource:
+	result = &GroupsDataSource{
+		logger:     parent.logger,
+		collection: collection,
+	}
+	return
+}
+
+func (s *GroupsDataSource) Read(ctx context.Context, request tfsdk.ReadDataSourceRequest,
+	response *tfsdk.ReadDataSourceResponse) {
+	// Get the state:
+	state := &GroupsState{}
+	diags := request.Config.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Fetch the complete list of groups of the cluster:
+	var listItems []*cmv1.Group
+	listSize := 10
+	listPage := 1
+	listRequest := s.collection.Cluster(state.Cluster.Value).Groups().List()
+	for {
+		listResponse, err := listRequest.SendContext(ctx)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't list groups",
+				err.Error(),
+			)
+			return
+		}
+		if listItems == nil {
+			listItems = make([]*cmv1.Group, 0, listResponse.Total())
+		}
+		listResponse.Items().Each(func(listItem *cmv1.Group) bool {
+			listItems = append(listItems, listItem)
+			return true
+		})
+		if listResponse.Size() < listSize {
+			break
+		}
+		listPage++
+		listRequest.Page(listPage)
+	}
+
+	// Populate the state:
+	state.Items = make([]*GroupState, len(listItems))
+	for i, listItem := range listItems {
+		state.Items[i] = &GroupState{
+			ID: types.String{
+				Value: listItem.ID(),
+			},
+			Name: types.String{
+				Value: listItem.ID(),
+			},
+		}
+	}
+
+	// Save the state:
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}

--- a/provider/groups_state.go
+++ b/provider/groups_state.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type GroupsState struct {
+	Cluster types.String  `tfsdk:"cluster"`
+	Items   []*GroupState `tfsdk:"items"`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -220,6 +220,7 @@ func (p *Provider) GetDataSources(ctx context.Context) (result map[string]tfsdk.
 	diags diag.Diagnostics) {
 	result = map[string]tfsdk.DataSourceType{
 		"ocm_cloud_providers": &CloudProvidersDataSourceType{},
+		"ocm_groups":          &GroupsDataSourceType{},
 		"ocm_machine_types":   &MachineTypesDataSourceType{},
 	}
 	return

--- a/tests/groups_data_source_test.go
+++ b/tests/groups_data_source_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"                         // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Groups data source", func() {
+	var ctx context.Context
+	var server *Server
+	var ca string
+	var token string
+
+	BeforeEach(func() {
+		// Create a contet:
+		ctx = context.Background()
+
+		// Create an access token:
+		token = MakeTokenString("Bearer", 10*time.Minute)
+
+		// Start the server:
+		server, ca = MakeTCPTLSServer()
+	})
+
+	AfterEach(func() {
+		// Stop the server:
+		server.Close()
+
+		// Remove the server CA file:
+		err := os.Remove(ca)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can list groups", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/groups"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 1,
+				  "total": 1,
+				  "items": [
+				    {
+				      "id": "dedicated-admins"
+				    }
+				  ]
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				data "ocm_groups" "my_groups" {
+				  cluster = "123"
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_groups", "my_groups")
+		Expect(resource).To(MatchJQ(`.attributes.items |length`, 1))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "dedicated-admins"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].name`, "dedicated-admins"))
+	})
+})


### PR DESCRIPTION
This patch adds a `ocm_groups` data source that can be used to list the
groups of users of a cluster.