### PR TITLE
Add group membership resource

### DIFF
--- a/docs/resources/ocm_group_membership.md
+++ b/docs/resources/ocm_group_membership.md
@@ -1,0 +1,38 @@
+---
+page_title: "ocm_group_membership Resource"
+subcategory: ""
+description: |-
+  Manages group membership.
+---
+
+# ocm_group_membership (Resource)
+
+This resource manages group membership. For example, to add the user `my-user`
+to the `dedicated-admins` group of a cluster:
+
+```hcl
+resource "ocm_group_membership" "my_admin" {
+  cluster = ocm_cluster.my_cluster.id
+  group   = "dedicated-admins"
+  user    = "my-user"
+}
+```
+
+Note that this will only add the user to the group, it will not create the user.
+To create users use the `ocm_identity_provider` resource to create an identity
+provider for the cluster and pupulate that identity provider with the users you
+need.
+
+## Schema
+
+### Required
+
+- **cluster** (String) Identifier of the cluster.
+
+- **group** (String) Identifier of the group, for example `dedicated-admins`.
+
+- **user** (String) Identifier of the user.
+
+### Read-Only
+
+- **id** (String) Unique identifier of the group membership.

--- a/examples/create_cluster/main.tf
+++ b/examples/create_cluster/main.tf
@@ -46,6 +46,12 @@ resource "ocm_identity_provider" "my_idp" {
   }
 }
 
+resource "ocm_group_membership" "my_admin" {
+  cluster = ocm.cluster.my_cluster.id
+  group   = "dedicated-admins"
+  user    = "admin"
+}
+
 resource "ocm_machine_pool" "my_pool" {
   cluster_id   = ocm_cluster.my_cluster.id
   name         = "my-pool"

--- a/provider/group_membership_resource.go
+++ b/provider/group_membership_resource.go
@@ -1,0 +1,239 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+type GroupMembershipResourceType struct {
+}
+
+type GroupMembershipResource struct {
+	logger     logging.Logger
+	collection *cmv1.ClustersClient
+}
+
+func (t *GroupMembershipResourceType) GetSchema(ctx context.Context) (result tfsdk.Schema,
+	diags diag.Diagnostics) {
+	result = tfsdk.Schema{
+		Description: "Manages user group membership.",
+		Attributes: map[string]tfsdk.Attribute{
+			"cluster": {
+				Description: "Identifier of the cluster.",
+				Type:        types.StringType,
+				Required:    true,
+			},
+			"group": {
+				Description: "Identifier of the group.",
+				Type:        types.StringType,
+				Required:    true,
+			},
+			"id": {
+				Description: "Identifier of the membership.",
+				Type:        types.StringType,
+				Computed:    true,
+			},
+			"user": {
+				Description: "user name.",
+				Type:        types.StringType,
+				Required:    true,
+			},
+		},
+	}
+	return
+}
+
+func (t *GroupMembershipResourceType) NewResource(ctx context.Context,
+	p tfsdk.Provider) (result tfsdk.Resource, diags diag.Diagnostics) {
+	// Cast the provider interface to the specific implementation: use it directly when needed.
+	parent := p.(*Provider)
+
+	// Get the collection of clusters:
+	collection := parent.connection.ClustersMgmt().V1().Clusters()
+
+	// Create the resource:
+	result = &GroupMembershipResource{
+		logger:     parent.logger,
+		collection: collection,
+	}
+
+	return
+}
+
+func (r *GroupMembershipResource) Create(ctx context.Context,
+	request tfsdk.CreateResourceRequest, response *tfsdk.CreateResourceResponse) {
+	// Get the plan:
+	state := &GroupMembershipState{}
+	diags := request.Plan.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Wait till the cluster is ready:
+	resource := r.collection.Cluster(state.Cluster.Value)
+	pollCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
+	defer cancel()
+	_, err := resource.Poll().
+		Interval(30 * time.Second).
+		Predicate(func(get *cmv1.ClusterGetResponse) bool {
+			return get.Body().State() == cmv1.ClusterStateReady
+		}).
+		StartContext(pollCtx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't poll cluster state",
+			fmt.Sprintf(
+				"Can't poll state of cluster with identifier '%s': %v",
+				state.Cluster.Value, err,
+			),
+		)
+		return
+	}
+
+	// Create the membership:
+	builder := cmv1.NewUser()
+	builder.ID(state.User.Value)
+	object, err := builder.Build()
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't build group membership",
+			fmt.Sprintf(
+				"Can't build group membership for cluster '%s' and group '%s': %v",
+				state.Cluster.Value, state.Group.Value, err,
+			),
+		)
+		return
+	}
+	collection := resource.Groups().Group(state.Group.Value).Users()
+	add, err := collection.Add().Body(object).SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't create group membership",
+			fmt.Sprintf(
+				"Can't create group membership for cluster '%s' and group '%s': %v",
+				state.Cluster.Value, state.Group.Value, err,
+			),
+		)
+		return
+	}
+	object = add.Body()
+
+	// Save the state:
+	r.populateState(object, state)
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}
+
+func (r *GroupMembershipResource) Read(ctx context.Context, request tfsdk.ReadResourceRequest,
+	response *tfsdk.ReadResourceResponse) {
+	// Get the current state:
+	state := &GroupMembershipState{}
+	diags := request.State.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Find the group membership:
+	resource := r.collection.Cluster(state.Cluster.Value).Groups().Group(state.Group.Value).
+		Users().
+		User(state.ID.Value)
+	get, err := resource.Get().SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't find group membership",
+			fmt.Sprintf(
+				"Can't find user group membership identifier '%s' for "+
+					"cluster '%s' and group '%s': %v",
+				state.ID.Value, state.Cluster.Value, state.Group.Value, err,
+			),
+		)
+		return
+	}
+	object := get.Body()
+
+	// Save the state:
+	r.populateState(object, state)
+	diags = response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}
+
+func (r *GroupMembershipResource) Update(ctx context.Context, request tfsdk.UpdateResourceRequest,
+	response *tfsdk.UpdateResourceResponse) {
+}
+
+func (r *GroupMembershipResource) Delete(ctx context.Context, request tfsdk.DeleteResourceRequest,
+	response *tfsdk.DeleteResourceResponse) {
+	// Get the state:
+	state := &GroupMembershipState{}
+	diags := request.State.Get(ctx, state)
+	response.Diagnostics.Append(diags...)
+	if response.Diagnostics.HasError() {
+		return
+	}
+
+	// Send the request to delete group membership:
+	resource := r.collection.Cluster(state.Cluster.Value).Groups().Group(state.Group.Value).
+		Users().
+		User(state.ID.Value)
+	_, err := resource.Delete().SendContext(ctx)
+	if err != nil {
+		response.Diagnostics.AddError(
+			"Can't delete group membership",
+			fmt.Sprintf(
+				"Can't delete group membership with identifier '%s' for "+
+					"cluster '%s' and group '%s': %v",
+				state.ID.Value, state.Cluster.Value, state.Group.Value, err,
+			),
+		)
+		return
+	}
+
+	// Remove the state:
+	response.State.RemoveResource(ctx)
+}
+
+func (r *GroupMembershipResource) ImportState(ctx context.Context, request tfsdk.ImportResourceStateRequest,
+	response *tfsdk.ImportResourceStateResponse) {
+	tfsdk.ResourceImportStatePassthroughID(
+		ctx,
+		tftypes.NewAttributePath().WithAttributeName("id"),
+		request,
+		response,
+	)
+}
+
+// populateState copies the data from the API object to the Terraform state.
+func (r *GroupMembershipResource) populateState(object *cmv1.User, state *GroupMembershipState) {
+	state.ID = types.String{
+		Value: object.ID(),
+	}
+	state.User = types.String{
+		Value: object.ID(),
+	}
+}

--- a/provider/group_membership_state.go
+++ b/provider/group_membership_state.go
@@ -1,0 +1,28 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type GroupMembershipState struct {
+	Cluster types.String `tfsdk:"cluster"`
+	Group   types.String `tfsdk:"group"`
+	ID      types.String `tfsdk:"id"`
+	User    types.String `tfsdk:"user"`
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -209,6 +209,7 @@ func (p *Provider) GetResources(ctx context.Context) (result map[string]tfsdk.Re
 	diags diag.Diagnostics) {
 	result = map[string]tfsdk.ResourceType{
 		"ocm_cluster":           &ClusterResourceType{},
+		"ocm_group_membership":  &GroupMembershipResourceType{},
 		"ocm_identity_provider": &IdentityProviderResourceType{},
 		"ocm_machine_pool":      &MachinePoolResourceType{},
 	}

--- a/tests/group_membership_resource_test.go
+++ b/tests/group_membership_resource_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"                         // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Group membership creation", func() {
+	var ctx context.Context
+	var server *Server
+	var ca string
+	var token string
+
+	BeforeEach(func() {
+		// Create a contet:
+		ctx = context.Background()
+
+		// Create an access token:
+		token = MakeTokenString("Bearer", 10*time.Minute)
+
+		// Start the server:
+		server, ca = MakeTCPTLSServer()
+
+		// The first thing that the provider will do for any operation on grups is check
+		// that the cluster is ready, so we always need to prepare the server to respond to
+		// that:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
+				RespondWithJSON(http.StatusOK, `{
+				  "id": "123",
+				  "name": "my-cluster",
+				  "state": "ready"
+				}`),
+			),
+		)
+	})
+
+	AfterEach(func() {
+		// Stop the server:
+		server.Close()
+
+		// Remove the server CA file:
+		err := os.Remove(ca)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can create a group membership", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(
+					http.MethodPost,
+					"/api/clusters_mgmt/v1/clusters/123/groups/dedicated-admins/users",
+				),
+				VerifyJSON(`{
+				  "kind": "User",
+				  "id": "my-admin"
+				}`),
+				RespondWithJSON(http.StatusOK, `{
+				  "id": "my-admin"
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				resource "ocm_group_membership" "my_membership" {
+				  cluster   = "123"
+				  group     = "dedicated-admins"
+				  user      = "my-admin"
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_group_membership", "my_membership")
+		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
+		Expect(resource).To(MatchJQ(".attributes.group", "dedicated-admins"))
+		Expect(resource).To(MatchJQ(".attributes.id", "my-admin"))
+		Expect(resource).To(MatchJQ(".attributes.user", "my-admin"))
+	})
+})


### PR DESCRIPTION
This patch adds a `ocm_group_membershp` resource that can be used to add
a user to a group of users of a cluster. For example, to add the user
`admin` to the `dedicated-admins` group:

```hcl
resource "ocm_group_membership" "my_admin" {
  cluster = ocm_cluster.my_cluster.id
  group    = "dedicated-admins"
  user     = "my-user"
}
```