### PR TITLE
Use `cluster` instead of `cluster_id`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,12 +37,18 @@ resource "ocm_cluster" "my_cluster" {
 }
 
 resource "ocm_identity_provider" "my_idp" {
-  cluster_id = ocm_cluster.my_cluster.id
-  name       = "my-idp"
+  cluster = ocm_cluster.my_cluster.id
+  name    = "my-idp"
   htpasswd = {
-    username = "my-user"
-    password = "my-password"
+    username = "admin"
+    password = "redhat123"
   }
+}
+
+resource "ocm_group_membership" "my_admin" {
+  cluster = ocm_cluster.my_cluster.id
+  group   = "dedicated-admins"
+  user    = "admin"
 }
 ```
 

--- a/docs/data-sources/ocm_groups.md
+++ b/docs/data-sources/ocm_groups.md
@@ -29,7 +29,7 @@ Read-Only:
 
 - **id** (String) Unique identifier of the group. This is what should be used
   when referencing the group from other places, for example in the `group`
-  attribute of the user resource.
+  attribute of the `ocm_group_membership` resource.
 
 - **name** (String) Short name of the group for example `dedicated-admins`.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -44,12 +44,18 @@ resource "ocm_cluster" "my_cluster" {
 }
 
 resource "ocm_identity_provider" "my_idp" {
-  cluster_id = ocm_cluster.my_cluster.id
-  name       = "my-idp"
+  cluster = ocm_cluster.my_cluster.id
+  name    = "my-idp"
   htpasswd = {
-    username = "my-user"
-    password = "my-password"
+    username = "admin"
+    password = "redhat123"
   }
+}
+
+resource "ocm_group_membership" "my_admin" {
+  cluster = ocm_cluster.my_cluster.id
+  group   = "dedicated-admins"
+  user    = "admin"
 }
 ```
 

--- a/docs/resources/ocm_identity_provider.md
+++ b/docs/resources/ocm_identity_provider.md
@@ -14,7 +14,7 @@ Identity provider.
 
 ### Required
 
-- **cluster_id** (String) Identifier of the cluster.
+- **cluster** (String) Identifier of the cluster.
 - **name** (String) Name of the identity provider.
 
 ### Optional

--- a/docs/resources/ocm_machine_pool.md
+++ b/docs/resources/ocm_machine_pool.md
@@ -13,7 +13,7 @@ Machine pool.
 
 ### Required
 
-- **cluster_id** (String) Identifier of the cluster.
+- **cluster** (String) Identifier of the cluster.
 
 - **machine_type** (String) Identifier of the machine type used by the nodes,
   for example `r5.xlarge`. Use the `ocm_machine_types` data source to find the

--- a/examples/create_cluster/main.tf
+++ b/examples/create_cluster/main.tf
@@ -38,8 +38,8 @@ resource "ocm_cluster" "my_cluster" {
 }
 
 resource "ocm_identity_provider" "my_idp" {
-  cluster_id = ocm_cluster.my_cluster.id
-  name       = "my-idp"
+  cluster = ocm_cluster.my_cluster.id
+  name    = "my-idp"
   htpasswd = {
     username = "admin"
     password = "redhat123"
@@ -53,7 +53,7 @@ resource "ocm_group_membership" "my_admin" {
 }
 
 resource "ocm_machine_pool" "my_pool" {
-  cluster_id   = ocm_cluster.my_cluster.id
+  cluster      = ocm_cluster.my_cluster.id
   name         = "my-pool"
   machine_type = "r5.xlarge"
   replicas     = 5

--- a/provider/identity_provider_resource.go
+++ b/provider/identity_provider_resource.go
@@ -42,7 +42,7 @@ func (t *IdentityProviderResourceType) GetSchema(ctx context.Context) (result tf
 	result = tfsdk.Schema{
 		Description: "Identity provider.",
 		Attributes: map[string]tfsdk.Attribute{
-			"cluster_id": {
+			"cluster": {
 				Description: "Identifier of the cluster.",
 				Type:        types.StringType,
 				Required:    true,
@@ -177,7 +177,7 @@ func (r *IdentityProviderResource) Create(ctx context.Context,
 	}
 
 	// Wait till the cluster is ready:
-	resource := r.collection.Cluster(state.ClusterID.Value)
+	resource := r.collection.Cluster(state.Cluster.Value)
 	pollCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 	_, err := resource.Poll().
@@ -191,7 +191,7 @@ func (r *IdentityProviderResource) Create(ctx context.Context,
 			"Can't poll cluster state",
 			fmt.Sprintf(
 				"Can't poll state of cluster with identifier '%s': %v",
-				state.ClusterID.Value, err,
+				state.Cluster.Value, err,
 			),
 		)
 		return
@@ -268,7 +268,7 @@ func (r *IdentityProviderResource) Create(ctx context.Context,
 			fmt.Sprintf(
 				"Can't create identity provider with name '%s' for "+
 					"cluster '%s': %v",
-				state.Name.Value, state.ClusterID.Value, err,
+				state.Name.Value, state.Cluster.Value, err,
 			),
 		)
 		return
@@ -312,7 +312,7 @@ func (r *IdentityProviderResource) Read(ctx context.Context, request tfsdk.ReadR
 	}
 
 	// Find the identity provider:
-	resource := r.collection.Cluster(state.ClusterID.Value).
+	resource := r.collection.Cluster(state.Cluster.Value).
 		IdentityProviders().
 		IdentityProvider(state.ID.Value)
 	get, err := resource.Get().SendContext(ctx)
@@ -322,7 +322,7 @@ func (r *IdentityProviderResource) Read(ctx context.Context, request tfsdk.ReadR
 			fmt.Sprintf(
 				"Can't find identity provider with identifier '%s' for "+
 					"cluster '%s': %v",
-				state.ID.Value, state.ClusterID.Value, err,
+				state.ID.Value, state.Cluster.Value, err,
 			),
 		)
 		return
@@ -434,7 +434,7 @@ func (r *IdentityProviderResource) Delete(ctx context.Context, request tfsdk.Del
 	}
 
 	// Send the request to delete the identity provider:
-	resource := r.collection.Cluster(state.ClusterID.Value).
+	resource := r.collection.Cluster(state.Cluster.Value).
 		IdentityProviders().
 		IdentityProvider(state.ID.Value)
 	_, err := resource.Delete().SendContext(ctx)
@@ -444,7 +444,7 @@ func (r *IdentityProviderResource) Delete(ctx context.Context, request tfsdk.Del
 			fmt.Sprintf(
 				"Can't delete identity provider with identifier '%s' for "+
 					"cluster '%s': %v",
-				state.ID.Value, state.ClusterID.Value, err,
+				state.ID.Value, state.Cluster.Value, err,
 			),
 		)
 		return

--- a/provider/identity_provider_state.go
+++ b/provider/identity_provider_state.go
@@ -21,11 +21,11 @@ import (
 )
 
 type IdentityProviderState struct {
-	ClusterID types.String              `tfsdk:"cluster_id"`
-	ID        types.String              `tfsdk:"id"`
-	Name      types.String              `tfsdk:"name"`
-	HTPasswd  *HTPasswdIdentityProvider `tfsdk:"htpasswd"`
-	LDAP      *LDAPIdentityProvider     `tfsdk:"ldap"`
+	Cluster  types.String              `tfsdk:"cluster"`
+	ID       types.String              `tfsdk:"id"`
+	Name     types.String              `tfsdk:"name"`
+	HTPasswd *HTPasswdIdentityProvider `tfsdk:"htpasswd"`
+	LDAP     *LDAPIdentityProvider     `tfsdk:"ldap"`
 }
 
 type HTPasswdIdentityProvider struct {

--- a/provider/machine_pool_resource.go
+++ b/provider/machine_pool_resource.go
@@ -42,7 +42,7 @@ func (t *MachinePoolResourceType) GetSchema(ctx context.Context) (result tfsdk.S
 	result = tfsdk.Schema{
 		Description: "Machine pool.",
 		Attributes: map[string]tfsdk.Attribute{
-			"cluster_id": {
+			"cluster": {
 				Description: "Identifier of the cluster.",
 				Type:        types.StringType,
 				Required:    true,
@@ -102,7 +102,7 @@ func (r *MachinePoolResource) Create(ctx context.Context,
 	}
 
 	// Wait till the cluster is ready:
-	resource := r.collection.Cluster(state.ClusterID.Value)
+	resource := r.collection.Cluster(state.Cluster.Value)
 	pollCtx, cancel := context.WithTimeout(ctx, 1*time.Hour)
 	defer cancel()
 	_, err := resource.Poll().
@@ -116,7 +116,7 @@ func (r *MachinePoolResource) Create(ctx context.Context,
 			"Can't poll cluster state",
 			fmt.Sprintf(
 				"Can't poll state of cluster with identifier '%s': %v",
-				state.ClusterID.Value, err,
+				state.Cluster.Value, err,
 			),
 		)
 		return
@@ -133,7 +133,7 @@ func (r *MachinePoolResource) Create(ctx context.Context,
 			"Can't build machine pool",
 			fmt.Sprintf(
 				"Can't build machine pool for cluster '%s': %v",
-				state.ClusterID.Value, err,
+				state.Cluster.Value, err,
 			),
 		)
 		return
@@ -145,7 +145,7 @@ func (r *MachinePoolResource) Create(ctx context.Context,
 			"Can't create machine pool",
 			fmt.Sprintf(
 				"Can't create machine pool for cluster '%s': %v",
-				state.ClusterID.Value, err,
+				state.Cluster.Value, err,
 			),
 		)
 		return
@@ -169,7 +169,7 @@ func (r *MachinePoolResource) Read(ctx context.Context, request tfsdk.ReadResour
 	}
 
 	// Find the identity provider:
-	resource := r.collection.Cluster(state.ClusterID.Value).
+	resource := r.collection.Cluster(state.Cluster.Value).
 		MachinePools().
 		MachinePool(state.ID.Value)
 	get, err := resource.Get().SendContext(ctx)
@@ -179,7 +179,7 @@ func (r *MachinePoolResource) Read(ctx context.Context, request tfsdk.ReadResour
 			fmt.Sprintf(
 				"Can't find machine pool with identifier '%s' for "+
 					"cluster '%s': %v",
-				state.ID.Value, state.ClusterID.Value, err,
+				state.ID.Value, state.Cluster.Value, err,
 			),
 		)
 		return
@@ -207,7 +207,7 @@ func (r *MachinePoolResource) Delete(ctx context.Context, request tfsdk.DeleteRe
 	}
 
 	// Send the request to delete the machine pool:
-	resource := r.collection.Cluster(state.ClusterID.Value).
+	resource := r.collection.Cluster(state.Cluster.Value).
 		MachinePools().
 		MachinePool(state.ID.Value)
 	_, err := resource.Delete().SendContext(ctx)
@@ -217,7 +217,7 @@ func (r *MachinePoolResource) Delete(ctx context.Context, request tfsdk.DeleteRe
 			fmt.Sprintf(
 				"Can't delete machine pool with identifier '%s' for "+
 					"cluster '%s': %v",
-				state.ID.Value, state.ClusterID.Value, err,
+				state.ID.Value, state.Cluster.Value, err,
 			),
 		)
 		return

--- a/provider/machine_pool_state.go
+++ b/provider/machine_pool_state.go
@@ -21,7 +21,7 @@ import (
 )
 
 type MachinePoolState struct {
-	ClusterID   types.String `tfsdk:"cluster_id"`
+	Cluster     types.String `tfsdk:"cluster"`
 	ID          types.String `tfsdk:"id"`
 	MachineType types.String `tfsdk:"machine_type"`
 	Name        types.String `tfsdk:"name"`

--- a/tests/identity_provider_resource_test.go
+++ b/tests/identity_provider_resource_test.go
@@ -115,9 +115,9 @@ var _ = Describe("Identity provider creation", func() {
 				}
 
 				resource "ocm_identity_provider" "my_ip" {
-				  cluster_id = "123"
-				  name       = "my-ip"
-				  htpasswd   = {
+				  cluster = "123"
+				  name    = "my-ip"
+				  htpasswd = {
 				    username = "my-user"
 				    password = "my-password"
 				  }
@@ -196,9 +196,9 @@ var _ = Describe("Identity provider creation", func() {
 				}
 
 				resource "ocm_identity_provider" "my_ip" {
-				  cluster_id    = "123"
-				  name          = "my-ip"
-				  ldap          = {
+				  cluster    = "123"
+				  name       = "my-ip"
+				  ldap = {
 				    bind_dn       = "my-bind-dn"
 				    bind_password = "my-bind-password"
 				    insecure      = false

--- a/tests/machine_pool_resource_test.go
+++ b/tests/machine_pool_resource_test.go
@@ -110,7 +110,7 @@ var _ = Describe("Machine pool creation", func() {
 				}
 
 				resource "ocm_machine_pool" "my_pool" {
-				  cluster_id   = "123"
+				  cluster      = "123"
 				  name         = "my-pool"
 				  machine_type = "r5.xlarge"
 				  replicas     = 10
@@ -125,7 +125,7 @@ var _ = Describe("Machine pool creation", func() {
 
 		// Check the state:
 		resource := result.Resource("ocm_machine_pool", "my_pool")
-		Expect(resource).To(MatchJQ(".attributes.cluster_id", "123"))
+		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
 		Expect(resource).To(MatchJQ(".attributes.id", "my-pool"))
 		Expect(resource).To(MatchJQ(".attributes.name", "my-pool"))
 		Expect(resource).To(MatchJQ(".attributes.machine_type", "r5.xlarge"))


### PR DESCRIPTION
Currently the provider uses `cluster_id` in places where a reference to
a cluster is required. That isn't consistent with other places where
references are required. For example, references to cloud providers use
`cloud_provider` and references to machine types use `machine_type`. To
make that a bit more consistent this place replaces `cluster_id` with
`cluster`.