### PR TITLE
Add support for _CCS_ clusters

### DIFF
--- a/docs/resources/ocm_cluster.md
+++ b/docs/resources/ocm_cluster.md
@@ -22,6 +22,20 @@ OpenShift managed cluster.
 
 ### Optional
 
+- **aws_account_id** (String) Identifier of the AWS account where the cluster
+  will be created. This is required when `ccs_enabled` is true.
+
+- **aws_access_key_id** (String) Identifier of the AWS access key that will be
+  used to create the cluster. This is required when `ccs_enabled` is true.
+
+- **aws_secret_access_key** (String) AWS access key that will be used to create
+  the cluster. This is required when `ccs_enabled` is `true`.
+
+- **ccs_enabled** (Boolean) Flag indicating if _customer cloud subscription_ is
+  enabled. Default value is `false`. If set to `true` then the cluster will be
+  created in an AWS account specified by the user with the `aws_account_id`,
+  `aws_access_key_id` and `aws_secret_access_key` attributes.
+
 - **compute_nodes** (Number) Number of compute nodes of the cluster.
 
 - **compute_machine_type** (String) Identifier of the machine type used by the

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/openshift-online/terraform-provider-ocm
 go 1.17
 
 require (
+	github.com/evanphx/json-patch/v5 v5.6.0
 	github.com/hashicorp/terraform-plugin-framework v0.4.2
 	github.com/hashicorp/terraform-plugin-go v0.4.0
 	github.com/itchyny/gojq v0.12.5
@@ -47,6 +48,7 @@ require (
 	github.com/modern-go/reflect2 v1.0.1 // indirect
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/oklog/run v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_golang v1.9.0 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.15.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,8 @@ github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymF
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
+github.com/evanphx/json-patch/v5 v5.6.0 h1:b91NhWfaz02IuVxO9faSllyAtNXHMPkC5J8sJCLunww=
+github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2VvlbKOFpnXhI9Bw4=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
@@ -243,6 +245,7 @@ github.com/jackc/puddle v0.0.0-20190608224051-11cab39313c9/go.mod h1:m4B5Dj62Y0f
 github.com/jackc/puddle v1.1.0/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/jackc/puddle v1.1.3/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
+github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=

--- a/provider/cluster_state.go
+++ b/provider/cluster_state.go
@@ -22,6 +22,10 @@ import (
 
 type ClusterState struct {
 	APIURL             types.String `tfsdk:"api_url"`
+	AWSAccessKeyID     types.String `tfsdk:"aws_access_key_id"`
+	AWSAccountID       types.String `tfsdk:"aws_account_id"`
+	AWSSecretAccessKey types.String `tfsdk:"aws_secret_access_key"`
+	CCSEnabled         types.Bool   `tfsdk:"ccs_enabled"`
 	CloudProvider      types.String `tfsdk:"cloud_provider"`
 	CloudRegion        types.String `tfsdk:"cloud_region"`
 	ComputeMachineType types.String `tfsdk:"compute_machine_type"`

--- a/tests/cluster_resource_test.go
+++ b/tests/cluster_resource_test.go
@@ -60,6 +60,9 @@ var _ = Describe("Cluster creation", func() {
 	      "id": "r5.xlarge"
 	    }
 	  },
+	  "ccs": {
+	    "enabled": false
+	  },
 	  "state": "ready"
 	}`
 
@@ -88,18 +91,9 @@ var _ = Describe("Cluster creation", func() {
 		server.AppendHandlers(
 			CombineHandlers(
 				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
-				VerifyJSON(`{
-				  "kind": "Cluster",
-				  "name": "my-cluster",
-				  "cloud_provider": {
-				    "kind": "CloudProvider",
-				    "id": "aws"
-				  },
-				  "region": {
-				    "kind": "CloudRegion",
-				    "id": "us-west-1"
-				  }
-				}`),
+				VerifyJQ(`.name`, "my-cluster"),
+				VerifyJQ(`.cloud_provider.id`, "aws"),
+				VerifyJQ(`.region.id`, "us-west-1"),
 				RespondWithJSON(http.StatusCreated, template),
 			),
 		)
@@ -182,75 +176,13 @@ var _ = Describe("Cluster creation", func() {
 		Expect(resource).To(MatchJQ(".attributes.console_url", "https://my-console.example.com"))
 	})
 
-	It("Saves console URL to the state", func() {
-		// Prepare the server:
-		server.AppendHandlers(
-			CombineHandlers(
-				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
-				RespondWithJSON(http.StatusCreated, template),
-			),
-		)
-
-		// Run the apply command:
-		result := NewTerraformRunner().
-			File(
-				"main.tf", `
-				terraform {
-				  required_providers {
-				    ocm = {
-				      source = "localhost/openshift-online/ocm"
-				    }
-				  }
-				}
-
-				provider "ocm" {
-				  url         = "{{ .URL }}"
-				  token       = "{{ .Token }}"
-				  trusted_cas = file("{{ .CA }}")
-				}
-
-				resource "ocm_cluster" "my_cluster" {
-				  name           = "my-cluster"
-				  cloud_provider = "aws"
-				  cloud_region   = "us-west-1"
-				}
-				`,
-				"URL", server.URL(),
-				"Token", token,
-				"CA", strings.ReplaceAll(ca, "\\", "/"),
-			).
-			Apply(ctx)
-		Expect(result.ExitCode()).To(BeZero())
-
-		// Check the state:
-		resource := result.Resource("ocm_cluster", "my_cluster")
-		Expect(resource).To(MatchJQ(".attributes.api_url", "https://my-api.example.com"))
-	})
-
 	It("Sets compute nodes and machine type", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
 				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
-				VerifyJSON(`{
-				  "kind": "Cluster",
-				  "name": "my-cluster",
-				  "cloud_provider": {
-				    "kind": "CloudProvider",
-				    "id": "aws"
-				  },
-				  "region": {
-				    "kind": "CloudRegion",
-				    "id": "us-west-1"
-				  },
-				  "nodes": {
-				    "compute": 3,
-				    "compute_machine_type": {
-				      "kind": "MachineType",
-				      "id": "r5.xlarge"
-				    }
-				  }
-				}`),
+				VerifyJQ(`.nodes.compute`, 3.0),
+				VerifyJQ(`.nodes.compute_machine_type.id`, "r5.xlarge"),
 				RespondWithJSON(http.StatusCreated, template),
 			),
 		)
@@ -292,6 +224,79 @@ var _ = Describe("Cluster creation", func() {
 		resource := result.Resource("ocm_cluster", "my_cluster")
 		Expect(resource).To(MatchJQ(".attributes.compute_nodes", 3.0))
 		Expect(resource).To(MatchJQ(".attributes.compute_machine_type", "r5.xlarge"))
+	})
+
+	It("Creates CCS cluster", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodPost, "/api/clusters_mgmt/v1/clusters"),
+				VerifyJQ(".ccs.enabled", true),
+				VerifyJQ(".aws.account_id", "123"),
+				VerifyJQ(".aws.access_key_id", "456"),
+				VerifyJQ(".aws.secret_access_key", "789"),
+				RespondWithPatchedJSON(http.StatusOK, template, `[
+				  {
+				    "op": "replace",
+				    "path": "/ccs",
+				    "value": {
+				      "enabled": true
+				    }
+				  },
+				  {
+				    "op": "add",
+				    "path": "/aws",
+				    "value": {
+				      "account_id": "123",
+				      "access_key_id": "456",
+				      "secret_access_key": "789"
+				    }
+				  }
+				]`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				resource "ocm_cluster" "my_cluster" {
+				  name                  = "my-cluster"
+				  cloud_provider        = "aws"
+				  cloud_region          = "us-west-1"
+				  ccs_enabled           = true
+				  aws_account_id        = "123"
+				  aws_access_key_id     = "456"
+				  aws_secret_access_key = "789"
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_cluster", "my_cluster")
+		Expect(resource).To(MatchJQ(".attributes.ccs_enabled", true))
+		Expect(resource).To(MatchJQ(".attributes.aws_account_id", "123"))
+		Expect(resource).To(MatchJQ(".attributes.aws_access_key_id", "456"))
+		Expect(resource).To(MatchJQ(".attributes.aws_secret_access_key", "789"))
 	})
 
 	It("Fails if the cluster already exists", func() {


### PR DESCRIPTION
This patch adds support for creating clusters in AWS accounts provided
by the user. For example:

```hcl
resource "ocm_cluster" "my_cluster" {
  name                  = "my-cluster"
  cloud_provider        = "aws"
  cloud_region          = "us-west-1"
  ccs_enabled           = true
  aws_account_id        = "135374424875"
  aws_access_key_id     = "AKJB2CMPQABCYMTUS78P"
  aws_secret_access_key = "Ob3E0gAULY7lbTqbFLpyZh2z64mybOfWmXmJhnQv"
}
```