### PR TITLE
Add network attributes

### DIFF
--- a/docs/resources/ocm_cluster.md
+++ b/docs/resources/ocm_cluster.md
@@ -22,11 +22,11 @@ OpenShift managed cluster.
 
 ### Optional
 
-- **aws_account_id** (String) Identifier of the AWS account where the cluster
-  will be created. This is required when `ccs_enabled` is true.
-
 - **aws_access_key_id** (String) Identifier of the AWS access key that will be
   used to create the cluster. This is required when `ccs_enabled` is true.
+
+- **aws_account_id** (String) Identifier of the AWS account where the cluster
+  will be created. This is required when `ccs_enabled` is true.
 
 - **aws_secret_access_key** (String) AWS access key that will be used to create
   the cluster. This is required when `ccs_enabled` is `true`.
@@ -45,6 +45,12 @@ OpenShift managed cluster.
   Note that the compute machine type of a cluster can't be changed. If you change
   the value of this attribute the cluster will be deleted and created again.
 
+- **host_prefix** (Number) Length of the prefix of the subnet assigned to each
+  node. Default value is `23`.
+
+- **machine_cidr** (String) Block of IP addresses for nodes. Default value is
+  `10.0.0.0/16`.
+
 - **multi_az** (Boolean) Indicates if the cluster should be deployed to multiple
   availability zones. Default value is 'false'.
 
@@ -52,7 +58,13 @@ OpenShift managed cluster.
   to use multiple availability zones. If you change the value of this attribute
   the cluster will be deleted and created again.
 
+- **pod_cidr** (String) Block of IP addresses for pods. Default value is
+  `172.30.0.0/16`.
+
 - **properties** (Map of String) User defined properties.
+
+- **service_cidr** (String) Block of IP addresses for services. Default value is
+  `172.30.0.0/16`.
 
 - **wait** (Boolean) Wait till the cluster is ready.
 

--- a/provider/cluster_state.go
+++ b/provider/cluster_state.go
@@ -31,10 +31,14 @@ type ClusterState struct {
 	ComputeMachineType types.String `tfsdk:"compute_machine_type"`
 	ComputeNodes       types.Int64  `tfsdk:"compute_nodes"`
 	ConsoleURL         types.String `tfsdk:"console_url"`
+	HostPrefix         types.Int64  `tfsdk:"host_prefix"`
 	ID                 types.String `tfsdk:"id"`
+	MachineCIDR        types.String `tfsdk:"machine_cidr"`
 	MultiAZ            types.Bool   `tfsdk:"multi_az"`
 	Name               types.String `tfsdk:"name"`
+	PodCIDR            types.String `tfsdk:"pod_cidr"`
 	Properties         types.Map    `tfsdk:"properties"`
+	ServiceCIDR        types.String `tfsdk:"service_cidr"`
 	State              types.String `tfsdk:"state"`
 	Wait               types.Bool   `tfsdk:"wait"`
 }


### PR DESCRIPTION
This patch to the `ocm_cluster` resource support for the `machine_cidr`,
`service_cidr`, `pod_cidr` and `host_prefix` attributes.