### PR TITLE
Add versions data source

### DIFF
--- a/docs/data-sources/ocm_versions.md
+++ b/docs/data-sources/ocm_versions.md
@@ -1,0 +1,29 @@
+---
+page_title: "ocm_versions Data Source"
+subcategory: ""
+description: |-
+  List of OpenShift versions.
+---
+
+# ocm_versions (Data Source)
+
+This data source lists the _OpenShift_ verions that can be used to create
+clusters.
+
+## Schema
+
+### Read-Only
+
+- **items** (Attributes List) Items of the list. (see [below for nested
+  schema](#nestedatt--items))
+
+<a id="nestedatt--items"></a>
+### Nested Schema for `items`
+
+Read-Only:
+
+- **id** (String) Identifier of the version. This is what should be used when
+  referencing the version from other places, for example in the `version`
+  attribute of the cluster resource.
+
+- **name** (String) Short name of the the version, for example `4.1.0`.

--- a/examples/list_versions/README.md
+++ b/examples/list_versions/README.md
@@ -1,0 +1,5 @@
+# Version list example
+
+This example shows how to use the versions data source to get a list of the
+supported _OpenShift_ versions. To run it adjust the configuration of the
+provider in the `main.tf` file and then run the `terraform apply` command.

--- a/examples/list_versions/main.tf
+++ b/examples/list_versions/main.tf
@@ -1,0 +1,35 @@
+#
+# Copyright (c) 2021 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+terraform {
+  required_providers {
+    ocm = {
+      version = ">= 0.1"
+      source  = "openshift-online/ocm"
+    }
+  }
+}
+
+provider "ocm" {
+}
+
+data "ocm_versions" "all" {
+}
+
+output "versions" {
+  description = "OpenShift versions"
+  value       = data.ocm_versions.all
+}

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -223,6 +223,7 @@ func (p *Provider) GetDataSources(ctx context.Context) (result map[string]tfsdk.
 		"ocm_cloud_providers": &CloudProvidersDataSourceType{},
 		"ocm_groups":          &GroupsDataSourceType{},
 		"ocm_machine_types":   &MachineTypesDataSourceType{},
+		"ocm_versions":        &VersionsDataSourceType{},
 	}
 	return
 }

--- a/provider/version_state.go
+++ b/provider/version_state.go
@@ -1,0 +1,26 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"github.com/hashicorp/terraform-plugin-framework/types"
+)
+
+type VersionState struct {
+	ID   types.String `tfsdk:"id"`
+	Name types.String `tfsdk:"name"`
+}

--- a/provider/versions_data_source.go
+++ b/provider/versions_data_source.go
@@ -1,0 +1,139 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+import (
+	"context"
+
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	cmv1 "github.com/openshift-online/ocm-sdk-go/clustersmgmt/v1"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+type VersionsDataSourceType struct {
+}
+
+type VersionsDataSource struct {
+	logger     logging.Logger
+	collection *cmv1.VersionsClient
+}
+
+func (t *VersionsDataSourceType) GetSchema(ctx context.Context) (result tfsdk.Schema,
+	diags diag.Diagnostics) {
+	result = tfsdk.Schema{
+		Description: "List of OpenShift versions.",
+		Attributes: map[string]tfsdk.Attribute{
+			"items": {
+				Description: "Items of the list.",
+				Attributes: tfsdk.ListNestedAttributes(
+					map[string]tfsdk.Attribute{
+						"id": {
+							Description: "Unique identifier of the " +
+								"version. This is what " +
+								"should be used when referencing " +
+								"the versions from other " +
+								"places, for example in the " +
+								"'version' attribute " +
+								"of the cluster resource.",
+							Type:     types.StringType,
+							Computed: true,
+						},
+						"name": {
+							Description: "Short name of the version " +
+								"provider, for example '4.1.0'.",
+							Type:     types.StringType,
+							Computed: true,
+						},
+					},
+					tfsdk.ListNestedAttributesOptions{},
+				),
+				Computed: true,
+			},
+		},
+	}
+	return
+}
+
+func (t *VersionsDataSourceType) NewDataSource(ctx context.Context,
+	p tfsdk.Provider) (result tfsdk.DataSource, diags diag.Diagnostics) {
+	// Cast the provider interface to the specific implementation:
+	parent := p.(*Provider)
+
+	// Get the collection of versions:
+	collection := parent.connection.ClustersMgmt().V1().Versions()
+
+	// Create the resource:
+	result = &VersionsDataSource{
+		logger:     parent.logger,
+		collection: collection,
+	}
+	return
+}
+
+func (s *VersionsDataSource) Read(ctx context.Context, request tfsdk.ReadDataSourceRequest,
+	response *tfsdk.ReadDataSourceResponse) {
+	// Fetch the list of verisions:
+	var listItems []*cmv1.Version
+	listSize := 100
+	listPage := 1
+	listRequest := s.collection.List().
+		Search("enabled = 't'").
+		Size(listSize)
+	for {
+		listResponse, err := listRequest.SendContext(ctx)
+		if err != nil {
+			response.Diagnostics.AddError(
+				"Can't list versions",
+				err.Error(),
+			)
+			return
+		}
+		if listItems == nil {
+			listItems = make([]*cmv1.Version, 0, listResponse.Total())
+		}
+		listResponse.Items().Each(func(listItem *cmv1.Version) bool {
+			listItems = append(listItems, listItem)
+			return true
+		})
+		if listResponse.Size() < listSize {
+			break
+		}
+		listPage++
+		listRequest.Page(listPage)
+	}
+
+	// Populate the state:
+	state := &VersionsState{
+		Items: make([]*VersionState, len(listItems)),
+	}
+	for i, listItem := range listItems {
+		state.Items[i] = &VersionState{
+			ID: types.String{
+				Value: listItem.ID(),
+			},
+			Name: types.String{
+				Value: listItem.RawID(),
+			},
+		}
+	}
+
+	// Save the state:
+	diags := response.State.Set(ctx, state)
+	response.Diagnostics.Append(diags...)
+}

--- a/provider/versions_state.go
+++ b/provider/versions_state.go
@@ -1,0 +1,21 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package provider
+
+type VersionsState struct {
+	Items []*VersionState `tfsdk:"items"`
+}

--- a/tests/versions_data_source_test.go
+++ b/tests/versions_data_source_test.go
@@ -1,0 +1,118 @@
+/*
+Copyright (c) 2021 Red Hat, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package tests
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"                         // nolint
+	. "github.com/onsi/gomega"                         // nolint
+	. "github.com/onsi/gomega/ghttp"                   // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+)
+
+var _ = Describe("Versions data source", func() {
+	var ctx context.Context
+	var server *Server
+	var ca string
+	var token string
+
+	BeforeEach(func() {
+		// Create a contet:
+		ctx = context.Background()
+
+		// Create an access token:
+		token = MakeTokenString("Bearer", 10*time.Minute)
+
+		// Start the server:
+		server, ca = MakeTCPTLSServer()
+	})
+
+	AfterEach(func() {
+		// Stop the server:
+		server.Close()
+
+		// Remove the server CA file:
+		err := os.Remove(ca)
+		Expect(err).ToNot(HaveOccurred())
+	})
+
+	It("Can list versions", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				VerifyFormKV("search", "enabled = 't'"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 2,
+				  "total": 2,
+				  "items": [
+				    {
+				      "id": "openshift-v4.8.1",
+				      "raw_id": "4.8.1"
+				    },
+				    {
+				      "id": "openshift-v4.8.2",
+				      "raw_id": "4.8.2"
+				    }
+				  ]
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				data "ocm_versions" "my_versions" {
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_versions", "my_versions")
+		Expect(resource).To(MatchJQ(`.attributes.items | length`, 2))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "openshift-v4.8.1"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].name`, "4.8.1"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].id`, "openshift-v4.8.2"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].name`, "4.8.2"))
+	})
+})


### PR DESCRIPTION
This patch adds a `ocm_versions` data source that lists the _OpenShift_
versions that can be used to install clusters.