### PR TITLE
Add `version` attribute

### DIFF
--- a/docs/resources/ocm_cluster.md
+++ b/docs/resources/ocm_cluster.md
@@ -66,6 +66,10 @@ OpenShift managed cluster.
 - **service_cidr** (String) Block of IP addresses for services. Default value is
   `172.30.0.0/16`.
 
+- **version** (String) Version of _OpenShift_ used to create the cluster, for
+  example `openshift-v4.9.7`. The default is to use the latest version. To get the
+  available versions use the `ocm_versions` data source.
+
 - **wait** (Boolean) Wait till the cluster is ready.
 
 ### Read-Only

--- a/examples/create_cluster/main.tf
+++ b/examples/create_cluster/main.tf
@@ -31,6 +31,7 @@ resource "ocm_cluster" "my_cluster" {
   cloud_provider = "aws"
   cloud_region   = "us-east-1"
   compute_nodes  = 10
+  version        = "openshift-v4.9.7"
   properties = {
     department  = "accounting"
     application = "billing"
@@ -47,7 +48,7 @@ resource "ocm_identity_provider" "my_idp" {
 }
 
 resource "ocm_group_membership" "my_admin" {
-  cluster = ocm.cluster.my_cluster.id
+  cluster = ocm_cluster.my_cluster.id
   group   = "dedicated-admins"
   user    = "admin"
 }

--- a/provider/cluster_resource.go
+++ b/provider/cluster_resource.go
@@ -157,6 +157,12 @@ func (t *ClusterResourceType) GetSchema(ctx context.Context) (result tfsdk.Schem
 				Optional:    true,
 				Computed:    true,
 			},
+			"version": {
+				Description: "Identifier of the version of OpenShift, for example 'openshift-v4.1.0'.",
+				Type:        types.StringType,
+				Optional:    true,
+				Computed:    true,
+			},
 			"state": {
 				Description: "State of the cluster.",
 				Type:        types.StringType,
@@ -261,6 +267,9 @@ func (r *ClusterResource) Create(ctx context.Context,
 	}
 	if !network.Empty() {
 		builder.Network(network)
+	}
+	if !state.Version.Unknown && !state.Version.Null {
+		builder.Version(cmv1.NewVersion().ID(state.Version.Value))
 	}
 	object, err := builder.Build()
 	if err != nil {
@@ -592,6 +601,16 @@ func (r *ClusterResource) populateState(object *cmv1.Cluster, state *ClusterStat
 		}
 	} else {
 		state.HostPrefix = types.Int64{
+			Null: true,
+		}
+	}
+	version, ok := object.Version().GetID()
+	if ok {
+		state.Version = types.String{
+			Value: version,
+		}
+	} else {
+		state.Version = types.String{
 			Null: true,
 		}
 	}

--- a/provider/cluster_state.go
+++ b/provider/cluster_state.go
@@ -40,5 +40,6 @@ type ClusterState struct {
 	Properties         types.Map    `tfsdk:"properties"`
 	ServiceCIDR        types.String `tfsdk:"service_cidr"`
 	State              types.String `tfsdk:"state"`
+	Version            types.String `tfsdk:"version"`
 	Wait               types.Bool   `tfsdk:"wait"`
 }


### PR DESCRIPTION
This patch adds the `version` attribute to the `ocm_cluster` resource.
For example, to create a cluster with version `4.9.7`:

```hcl
resource "ocm_cluster" "my_cluster" {
  name           = "my-cluster"
  cloud_provider = "aws"
  cloud_region   = "us-east-1"
  version        = "openshift-v4.9.7"
}
```