### PR TITLE
Move tests to provider package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ build:
 
 .PHONY: test tests
 test tests: build
-	ginkgo -ldflags="$(ldflags)" -r tests
+	ginkgo -ldflags="$(ldflags)" -r
 
 .PHONY: fmt_go
 fmt_go:

--- a/provider/cloud_providers_data_source_test.go
+++ b/provider/cloud_providers_data_source_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"
@@ -23,10 +23,11 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"                         // nolint
-	. "github.com/onsi/gomega"                         // nolint
-	. "github.com/onsi/gomega/ghttp"                   // nolint
-	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+	. "github.com/onsi/ginkgo"                                     // nolint
+	. "github.com/onsi/gomega"                                     // nolint
+	. "github.com/onsi/gomega/ghttp"                               // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing"             // nolint
+	. "github.com/openshift-online/terraform-provider-ocm/testing" // nolint
 )
 
 var _ = Describe("Cloud providers data source", func() {

--- a/provider/cluster_resource_test.go
+++ b/provider/cluster_resource_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"
@@ -23,10 +23,11 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"                         // nolint
-	. "github.com/onsi/gomega"                         // nolint
-	. "github.com/onsi/gomega/ghttp"                   // nolint
-	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+	. "github.com/onsi/ginkgo"                                     // nolint
+	. "github.com/onsi/gomega"                                     // nolint
+	. "github.com/onsi/gomega/ghttp"                               // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing"             // nolint
+	. "github.com/openshift-online/terraform-provider-ocm/testing" // nolint
 )
 
 var _ = Describe("Cluster creation", func() {

--- a/provider/groups_data_source_test.go
+++ b/provider/groups_data_source_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"                         // nolint
-	. "github.com/onsi/gomega"                         // nolint
-	. "github.com/onsi/gomega/ghttp"                   // nolint
-	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+	. "github.com/onsi/ginkgo"                                     // nolint
+	. "github.com/onsi/gomega"                                     // nolint
+	. "github.com/onsi/gomega/ghttp"                               // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing"             // nolint
+	. "github.com/openshift-online/terraform-provider-ocm/testing" // nolint
 )
 
-var _ = Describe("Versions data source", func() {
+var _ = Describe("Groups data source", func() {
 	var ctx context.Context
 	var server *Server
 	var ca string
@@ -55,24 +56,18 @@ var _ = Describe("Versions data source", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Can list versions", func() {
+	It("Can list groups", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
-				VerifyFormKV("search", "enabled = 't'"),
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/groups"),
 				RespondWithJSON(http.StatusOK, `{
 				  "page": 1,
-				  "size": 2,
-				  "total": 2,
+				  "size": 1,
+				  "total": 1,
 				  "items": [
 				    {
-				      "id": "openshift-v4.8.1",
-				      "raw_id": "4.8.1"
-				    },
-				    {
-				      "id": "openshift-v4.8.2",
-				      "raw_id": "4.8.2"
+				      "id": "dedicated-admins"
 				    }
 				  ]
 				}`),
@@ -97,7 +92,8 @@ var _ = Describe("Versions data source", func() {
 				  trusted_cas = file("{{ .CA }}")
 				}
 
-				data "ocm_versions" "my_versions" {
+				data "ocm_groups" "my_groups" {
+				  cluster = "123"
 				}
 				`,
 				"URL", server.URL(),
@@ -108,11 +104,9 @@ var _ = Describe("Versions data source", func() {
 		Expect(result.ExitCode()).To(BeZero())
 
 		// Check the state:
-		resource := result.Resource("ocm_versions", "my_versions")
-		Expect(resource).To(MatchJQ(`.attributes.items | length`, 2))
-		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "openshift-v4.8.1"))
-		Expect(resource).To(MatchJQ(`.attributes.items[0].name`, "4.8.1"))
-		Expect(resource).To(MatchJQ(`.attributes.items[1].id`, "openshift-v4.8.2"))
-		Expect(resource).To(MatchJQ(`.attributes.items[1].name`, "4.8.2"))
+		resource := result.Resource("ocm_groups", "my_groups")
+		Expect(resource).To(MatchJQ(`.attributes.items |length`, 1))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "dedicated-admins"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].name`, "dedicated-admins"))
 	})
 })

--- a/provider/identity_provider_resource_test.go
+++ b/provider/identity_provider_resource_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"

--- a/provider/init_test.go
+++ b/provider/init_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"

--- a/provider/machine_types_data_source_test.go
+++ b/provider/machine_types_data_source_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"
@@ -23,10 +23,11 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"                         // nolint
-	. "github.com/onsi/gomega"                         // nolint
-	. "github.com/onsi/gomega/ghttp"                   // nolint
-	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+	. "github.com/onsi/ginkgo"                                     // nolint
+	. "github.com/onsi/gomega"                                     // nolint
+	. "github.com/onsi/gomega/ghttp"                               // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing"             // nolint
+	. "github.com/openshift-online/terraform-provider-ocm/testing" // nolint
 )
 
 var _ = Describe("Machine types data source", func() {

--- a/provider/main_test.go
+++ b/provider/main_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"
@@ -29,10 +29,11 @@ import (
 	"testing"
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
-	sdktesting "github.com/openshift-online/ocm-sdk-go/testing"
 
-	. "github.com/onsi/ginkgo" // nolint
-	. "github.com/onsi/gomega" // nolint
+	. "github.com/onsi/ginkgo"                                     // nolint
+	. "github.com/onsi/gomega"                                     // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing"             // nolint
+	. "github.com/openshift-online/terraform-provider-ocm/testing" // nolint
 )
 
 func TestProvider(t *testing.T) {
@@ -79,7 +80,7 @@ func NewTerraformRunner() *TerraformRunner {
 // File adds a file that will be created in the directory where Terraform will run. The content of
 // the file will be generated from the given template and variables.
 func (r *TerraformRunner) File(name, template string, vars ...interface{}) *TerraformRunner {
-	r.files[name] = sdktesting.EvaluateTemplate(template, vars...)
+	r.files[name] = EvaluateTemplate(template, vars...)
 	return r
 }
 
@@ -128,7 +129,7 @@ func (r *TerraformRunner) Run(ctx context.Context) *TerraformResult {
 	Expect(err).ToNot(HaveOccurred())
 	projectDir := filepath.Dir(currentDir)
 	configPath := filepath.Join(tmpDir, "terraform.rc")
-	configText := sdktesting.EvaluateTemplate(
+	configText := EvaluateTemplate(
 		`
 		provider_installation {
 		  filesystem_mirror {
@@ -281,5 +282,5 @@ func RespondWithPatchedJSON(status int, body string, patch string) http.HandlerF
 	Expect(err).ToNot(HaveOccurred())
 	patchResult, err := patchObject.Apply([]byte(body))
 	Expect(err).ToNot(HaveOccurred())
-	return sdktesting.RespondWithJSON(status, string(patchResult))
+	return RespondWithJSON(status, string(patchResult))
 }

--- a/provider/versions_data_source_test.go
+++ b/provider/versions_data_source_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package provider
 
 import (
 	"context"
@@ -23,13 +23,14 @@ import (
 	"strings"
 	"time"
 
-	. "github.com/onsi/ginkgo"                         // nolint
-	. "github.com/onsi/gomega"                         // nolint
-	. "github.com/onsi/gomega/ghttp"                   // nolint
-	. "github.com/openshift-online/ocm-sdk-go/testing" // nolint
+	. "github.com/onsi/ginkgo"                                     // nolint
+	. "github.com/onsi/gomega"                                     // nolint
+	. "github.com/onsi/gomega/ghttp"                               // nolint
+	. "github.com/openshift-online/ocm-sdk-go/testing"             // nolint
+	. "github.com/openshift-online/terraform-provider-ocm/testing" // nolint
 )
 
-var _ = Describe("Groups data source", func() {
+var _ = Describe("Versions data source", func() {
 	var ctx context.Context
 	var server *Server
 	var ca string
@@ -55,18 +56,24 @@ var _ = Describe("Groups data source", func() {
 		Expect(err).ToNot(HaveOccurred())
 	})
 
-	It("Can list groups", func() {
+	It("Can list versions", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/groups"),
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				VerifyFormKV("search", "enabled = 't'"),
 				RespondWithJSON(http.StatusOK, `{
 				  "page": 1,
-				  "size": 1,
-				  "total": 1,
+				  "size": 2,
+				  "total": 2,
 				  "items": [
 				    {
-				      "id": "dedicated-admins"
+				      "id": "openshift-v4.8.1",
+				      "raw_id": "4.8.1"
+				    },
+				    {
+				      "id": "openshift-v4.8.2",
+				      "raw_id": "4.8.2"
 				    }
 				  ]
 				}`),
@@ -91,8 +98,7 @@ var _ = Describe("Groups data source", func() {
 				  trusted_cas = file("{{ .CA }}")
 				}
 
-				data "ocm_groups" "my_groups" {
-				  cluster = "123"
+				data "ocm_versions" "my_versions" {
 				}
 				`,
 				"URL", server.URL(),
@@ -103,9 +109,11 @@ var _ = Describe("Groups data source", func() {
 		Expect(result.ExitCode()).To(BeZero())
 
 		// Check the state:
-		resource := result.Resource("ocm_groups", "my_groups")
-		Expect(resource).To(MatchJQ(`.attributes.items |length`, 1))
-		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "dedicated-admins"))
-		Expect(resource).To(MatchJQ(`.attributes.items[0].name`, "dedicated-admins"))
+		resource := result.Resource("ocm_versions", "my_versions")
+		Expect(resource).To(MatchJQ(`.attributes.items | length`, 2))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "openshift-v4.8.1"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].name`, "4.8.1"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].id`, "openshift-v4.8.2"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].name`, "4.8.2"))
 	})
 })

--- a/testing/jq.go
+++ b/testing/jq.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package tests
+package testing
 
 import (
 	"bytes"


### PR DESCRIPTION
This patch moves the tests from the `tests` directory to the package of
the code that they test.