### PR TITLE
Add `search` and `order` to versions data source

### DIFF
--- a/docs/data-sources/ocm_versions.md
+++ b/docs/data-sources/ocm_versions.md
@@ -12,8 +12,74 @@ clusters.
 
 ## Schema
 
+- **order** (String) Order criteria.
+
+  The syntax of this parameter is similar to the syntax of the _order by_ clause
+  of a SQL statement, but using the names of the attributes of the version
+  instead of the names of the columns of a table. For example, in order to sort
+  the versions descending by identifier the value should be:
+
+  ```sql
+  id desc
+  ```
+
+  If the parameter isn't provided, or if the value is empty, then the order of
+  the results is undefined.
+
+- **search** (String) Search criteria.
+
+  The syntax of this parameter is similar to the syntax of the _where_ clause of
+  a SQL statement, but using the names of the attributes of the version instead
+  of the names of the columns of a table. For example, in order to retrieve all
+  the versions from the _fast_ channel group:
+
+  ```sql
+  enabled = 't' and channel_group = 'fast'
+  ```
+
+  Note that the default is to search for enabled versions, equivalent to
+  `enabled = 't'`. If you set this attribute that default value will be
+  overriden. Make sure to add it to your search criteria unless you also want
+  the versions that are disabled.
+
 ### Read-Only
 
+- **item** (Attributes) Content of the list when it has exactly one item. (see
+  [below for nested schema](#nestedatt--items))
+
+  This is intended to simplify use of the results in typical use cases, like
+  searching for a specific version. For example, to search for the versions in
+  the `fast` channel group and use the first one:
+
+  ```hcl
+  data "ocm_versions" "fast" {
+    search = "enabled = 't' and channel_group = 'fast'"
+    order  = "id asc"
+  }
+
+  resource "ocm_cluster" "my_cluster" {
+    name    = "my-cluster"
+    version = data.ocm_versions.fast.item.id
+    ...
+  }
+  ```
+
+  You can also use the `items` attribute, which is always populated, but it is
+  more verbose because it requires converting the result with the `tolist`
+  function:
+
+  ```hcl
+  data "ocm_versions" "fast" {
+    search = "enabled = 't' and channel_group = 'fast'"
+    order  = "id asc"
+  }
+
+  resource "ocm_cluster" "my_cluster" {
+    name    = "my-cluster"
+    version = tolist(data.ocm_versions.fast.items)[0].id
+    ...
+  }
+  ```
 - **items** (Attributes List) Items of the list. (see [below for nested
   schema](#nestedatt--items))
 

--- a/provider/cloud_providers_data_source.go
+++ b/provider/cloud_providers_data_source.go
@@ -163,6 +163,8 @@ func (s *CloudProvidersDataSource) Read(ctx context.Context, request tfsdk.ReadD
 	}
 	if len(state.Items) == 1 {
 		state.Item = state.Items[0]
+	} else {
+		state.Item = nil
 	}
 
 	// Save the state:

--- a/provider/cloud_providers_data_source_test.go
+++ b/provider/cloud_providers_data_source_test.go
@@ -291,7 +291,7 @@ var _ = Describe("Cloud providers data source", func() {
 		Expect(resource).To(MatchJQ(`.attributes.item`, nil))
 	})
 
-	It("Doesn't populate `item` if there multiple results", func() {
+	It("Doesn't populate `item` if there are multiple results", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(

--- a/provider/versions_data_source_test.go
+++ b/provider/versions_data_source_test.go
@@ -115,4 +115,224 @@ var _ = Describe("Versions data source", func() {
 		Expect(resource).To(MatchJQ(`.attributes.items[1].id`, "openshift-v4.8.2"))
 		Expect(resource).To(MatchJQ(`.attributes.items[1].name`, "4.8.2"))
 	})
+
+	It("Can search versions", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				VerifyFormKV("search", "enabled = 't' and channel_group = 'fast'"),
+				VerifyFormKV("order", "raw_id desc"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 2,
+				  "total": 2,
+				  "items": [
+				    {
+				      "id": "openshift-v4.8.1-fast",
+				      "raw_id": "4.8.1"
+				    },
+				    {
+				      "id": "openshift-v4.8.2-fast",
+				      "raw_id": "4.8.2"
+				    }
+				  ]
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				data "ocm_versions" "my_versions" {
+				  search = "enabled = 't' and channel_group = 'fast'"
+				  order  = "raw_id desc"
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_versions", "my_versions")
+		Expect(resource).To(MatchJQ(`.attributes.items | length`, 2))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].id`, "openshift-v4.8.1-fast"))
+		Expect(resource).To(MatchJQ(`.attributes.items[0].name`, "4.8.1"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].id`, "openshift-v4.8.2-fast"))
+		Expect(resource).To(MatchJQ(`.attributes.items[1].name`, "4.8.2"))
+	})
+
+	It("Populates `item` if there is exactly one result", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 1,
+				  "total": 1,
+				  "items": [
+				    {
+				      "id": "openshift-v4.8.1",
+				      "raw_id": "4.8.1"
+				    }
+				  ]
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				data "ocm_versions" "my_versions" {
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_versions", "my_versions")
+		Expect(resource).To(MatchJQ(`.attributes.item.id`, "openshift-v4.8.1"))
+		Expect(resource).To(MatchJQ(`.attributes.item.name`, "4.8.1"))
+	})
+
+	It("Doesn't populate `item` if there are zero results", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 0,
+				  "total": 0,
+				  "items": []
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				data "ocm_versions" "my_versions" {
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_versions", "my_versions")
+		Expect(resource).To(MatchJQ(`.attributes.item`, nil))
+	})
+
+	It("Doesn't populate `item` if there are multiple results", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/versions"),
+				RespondWithJSON(http.StatusOK, `{
+				  "page": 1,
+				  "size": 2,
+				  "total": 2,
+				  "items": [
+				    {
+				      "id": "openshift-v4.8.1",
+				      "raw_id": "4.8.1"
+				    },
+				    {
+				      "id": "openshift-v4.8.2",
+				      "raw_id": "4.8.2"
+				    }
+				  ]
+				}`),
+			),
+		)
+
+		// Run the apply command:
+		result := NewTerraformRunner().
+			File(
+				"main.tf", `
+				terraform {
+				  required_providers {
+				    ocm = {
+				      source = "localhost/openshift-online/ocm"
+				    }
+				  }
+				}
+
+				provider "ocm" {
+				  url         = "{{ .URL }}"
+				  token       = "{{ .Token }}"
+				  trusted_cas = file("{{ .CA }}")
+				}
+
+				data "ocm_versions" "my_versions" {
+				}
+				`,
+				"URL", server.URL(),
+				"Token", token,
+				"CA", strings.ReplaceAll(ca, "\\", "/"),
+			).
+			Apply(ctx)
+		Expect(result.ExitCode()).To(BeZero())
+
+		// Check the state:
+		resource := result.Resource("ocm_versions", "my_versions")
+		Expect(resource).To(MatchJQ(`.attributes.item`, nil))
+	})
 })

--- a/provider/versions_state.go
+++ b/provider/versions_state.go
@@ -16,6 +16,11 @@ limitations under the License.
 
 package provider
 
+import "github.com/hashicorp/terraform-plugin-framework/types"
+
 type VersionsState struct {
-	Items []*VersionState `tfsdk:"items"`
+	Search types.String    `tfsdk:"search"`
+	Order  types.String    `tfsdk:"order"`
+	Item   *VersionState   `tfsdk:"item"`
+	Items  []*VersionState `tfsdk:"items"`
 }


### PR DESCRIPTION
This patch adds the `search` and `order` attributes to the versions data
source.