### PR TITLE
Add the Terrafrom registry manifest file

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,9 @@ archives:
 - format: zip
   name_template: '{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}'
 checksum:
+  extra_files:
+  - glob: 'terraform-registry-manifest.json'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: '{{ .ProjectName }}_{{ .Version }}_SHA256SUMS'
   algorithm: sha256
 signs:
@@ -44,7 +47,9 @@ signs:
   - '--detach-sign'
   - '${artifact}'
 release:
+  extra_files:
+  - glob: 'terraform-registry-manifest.json'
+    name_template: '{{ .ProjectName }}_{{ .Version }}_manifest.json'
   name_template: 'Release {{ .Version }}'
 changelog:
   skip: true
-

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "metadata": {
+    "protocol_versions": [
+      "6.0"
+    ]
+  }
+}


### PR DESCRIPTION
This patch adds the `terraform-registry-manifest.json` file that
indicates to Terraform what version of the plugin protocol is used by
the provider.