### PR TITLE
Adding arm64 to build matrix

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,6 +26,7 @@ builds:
   - windows
   goarch:
   - amd64
+  - arm64
   binary: '{{ .ProjectName }}_v{{ .Version }}'
 archives:
 - format: zip


### PR DESCRIPTION
I'm on an M1 Mac, and when I tried to pull the provider it of course couldn't find the built binary. I added the `arm64` arch to the build matrix, then ran `goreleaser` locally and was able to do a `terraform init` with the provider configured, as well as an `apply` with a simple cluster config that seemed to have worked. 