### PR TITLE
Splitting operator roles creation from the ROSA STS cluster creation

### DIFF
--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/README.md
@@ -1,23 +1,9 @@
-# ROSA STS cluster creation example
+# ROSA STS cluster with operator IAM roles creation example
 
-This example shows how to create an STS _ROSA_ cluster. _ROSA_ stands for Red Hat Openshift Service on AWS
+This example shows how to create an STS _ROSA_ cluster and operator IAM roles . _ROSA_ stands for Red Hat Openshift Service on AWS
 and is a cluster that is created in the AWS cloud infrastructure.
+In order to create an STS cluster the user also need to create a specific IAM roles called "operator IAM roles" and oidc provider. 
 
-To run it:
-
-* Provide OCM Authentication Token
-
-OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
-
-```
-export TF_VAR_token=...
-```
-
-* Decide STS operator_role_prefix
-
-```
-export TF_VAR_operator_role_prefix==...
-```
-
-`main.tf` file and then run the `terraform apply` command.
-
+To run it you should create the resources on that order: 
+* Create a cluster 
+* Create the operator IAM roles and oidc provider

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/README.md
@@ -4,6 +4,8 @@ This example shows how to create an STS _ROSA_ cluster and operator IAM roles . 
 and is a cluster that is created in the AWS cloud infrastructure.
 In order to create an STS cluster the user also need to create a specific IAM roles called "operator IAM roles" and oidc provider. 
 
-To run it you should create the resources on that order: 
+To run it you should create the resources in the following order: 
 * Create a cluster 
 * Create the operator IAM roles and oidc provider
+
+To remove the cluster, you shouldn't remove the operator IAM roles till the cluster was successfully removed. 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/README.md
@@ -1,0 +1,29 @@
+# ROSA STS cluster creation example
+
+This example shows how to create an STS _ROSA_ cluster. _ROSA_ stands for Red Hat Openshift Service on AWS
+and is a cluster that is created in the AWS cloud infrastructure.
+
+To run it:
+
+* Provide OCM Authentication Token
+
+OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
+
+```
+export TF_VAR_token=...
+```
+
+* Provide OCM environment by setting a value to url
+
+```
+export TF_VAR_url=...
+```
+
+* Decide STS operator_role_prefix
+
+```
+export TF_VAR_operator_role_prefix=...
+```
+
+and then run the `terraform apply` command.
+

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/README.md
@@ -5,25 +5,22 @@ and is a cluster that is created in the AWS cloud infrastructure.
 
 To run it:
 
-* Provide OCM Authentication Token
+* Provide OCM Authentication Token 
 
-OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
+  OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
+    ```
+    export TF_VAR_token=...
+    ```
 
-```
-export TF_VAR_token=...
-```
+* Provide OCM environment by setting a value to url    
+    ```
+    export TF_VAR_url=...
+    ```
 
-* Provide OCM environment by setting a value to url
-
-```
-export TF_VAR_url=...
-```
-
-* Decide STS operator_role_prefix
-
-```
-export TF_VAR_operator_role_prefix=...
-```
+* Decide STS operator_role_prefix    
+    ```
+    export TF_VAR_operator_role_prefix=...
+    ```
 
 and then run the `terraform apply` command.
 

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/main.tf
@@ -27,7 +27,6 @@ terraform {
   }
 }
 
-
 provider "ocm" {
   token = var.token
   url = var.url
@@ -57,19 +56,4 @@ resource "ocm_cluster_rosa_classic" "rosa_sts_cluster" {
     rosa_creator_arn = data.aws_caller_identity.current.arn
   }
   sts = local.sts_roles
-}
-
-data "ocm_rosa_operator_roles" "operator_roles" {
-  cluster_id = ocm_cluster_rosa_classic.rosa_sts_cluster.id
-  operator_role_prefix = var.operator_role_prefix
-  account_role_prefix = var.account_role_prefix
-}
-
-module operator_roles {
-    source  = "git::https://github.com/openshift-online/terraform-provider-ocm.git//modules/aws_roles"
-
-    cluster_id = ocm_cluster_rosa_classic.rosa_sts_cluster.id
-    rh_oidc_provider_thumbprint = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.thumbprint
-    rh_oidc_provider_url = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
-    operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/output.tf
@@ -1,15 +1,11 @@
-output operator_iam_roles {
-  value =  data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
-}
-
 output cluster_id {
   value = ocm_cluster_rosa_classic.rosa_sts_cluster.id
 }
 
-output rh_oidc_provider_thumbprint {
+output oidc_thumbprint {
   value = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.thumbprint
 }
 
-output rh_oidc_provider_url {
+output oidc_endpoint_url {
    value = ocm_cluster_rosa_classic.rosa_sts_cluster.sts.oidc_endpoint_url
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/cluster/variables.tf
@@ -1,0 +1,13 @@
+variable token {
+  type = string
+  sensitive = true
+}
+
+variable operator_role_prefix {
+    type = string
+}
+
+variable url {
+    type = string
+    default = "https://api.openshift.com"
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/README.md
@@ -7,46 +7,46 @@ To run it:
 
 * Provide OCM Authentication Token
 
-OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
+    OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
 
-```
-export TF_VAR_token=...
-```
+    ```
+    export TF_VAR_token=...
+    ```
 
 * Provide OCM environment by setting a value to url
 
-```
-export TF_VAR_url=...
-```
+    ```
+    export TF_VAR_url=...
+    ```
 
 * Decide STS operator_role_prefix
 
-```
-export TF_VAR_operator_role_prefix=...
-```
+    ```
+    export TF_VAR_operator_role_prefix=...
+    ```
 
 * Provide value to cluster_id
-
-```
-export TF_VAR_cluster_id=...
-```
+    
+    ```
+    export TF_VAR_cluster_id=...
+    ```
 
 * Provide oidc_endpoint_url
 
-```
-export TF_VAR_oidc_endpoint_url=...
-```
+    ```
+    export TF_VAR_oidc_endpoint_url=...
+    ```
 
 * Provide value to oidc_thumbprint
-
-```
-export TF_VAR_oidc_thumbprint=...
-```
+    
+    ```
+    export TF_VAR_oidc_thumbprint=...
+    ```
 
 * Decide STS account_role_prefix. if not set use the default account IAM roles
-
-```
-export TF_VAR_account_role_prefix=...
-```
+    
+    ```
+    export TF_VAR_account_role_prefix=...
+    ```
 
 and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/README.md
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/README.md
@@ -1,0 +1,52 @@
+# ROSA STS cluster creation example
+
+This example shows how to create an operator IAM roles and oidc provider for an existing ROSA STS cluster.
+The variables are depended on the output of ROSA STS cluster creation.
+
+To run it:
+
+* Provide OCM Authentication Token
+
+OCM authentication token that you can get [here](https://console.redhat.com/openshift/token).
+
+```
+export TF_VAR_token=...
+```
+
+* Provide OCM environment by setting a value to url
+
+```
+export TF_VAR_url=...
+```
+
+* Decide STS operator_role_prefix
+
+```
+export TF_VAR_operator_role_prefix=...
+```
+
+* Provide value to cluster_id
+
+```
+export TF_VAR_cluster_id=...
+```
+
+* Provide oidc_endpoint_url
+
+```
+export TF_VAR_oidc_endpoint_url=...
+```
+
+* Provide value to oidc_thumbprint
+
+```
+export TF_VAR_oidc_thumbprint=...
+```
+
+* Decide STS account_role_prefix. if not set use the default account IAM roles
+
+```
+export TF_VAR_account_role_prefix=...
+```
+
+and then run the `terraform apply` command.

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/main.tf
@@ -1,0 +1,49 @@
+#
+# Copyright (c) 2022 Red Hat, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.20.0"
+    }
+    ocm = {
+      version = ">= 0.1"
+      source  = "openshift-online/ocm"
+    }
+  }
+}
+
+
+provider "ocm" {
+  token = var.token
+  url = var.url
+}
+
+data "ocm_rosa_operator_roles" "operator_roles" {
+  cluster_id =var.cluster_id
+  operator_role_prefix = var.operator_role_prefix
+  account_role_prefix = var.account_role_prefix
+}
+
+module operator_roles {
+    source  = "git::https://github.com/openshift-online/terraform-provider-ocm.git//modules/aws_roles"
+
+    cluster_id = var.cluster_id
+    rh_oidc_provider_thumbprint = var.oidc_thumbprint
+    rh_oidc_provider_url = var.oidc_endpoint_url
+    operator_roles_properties = data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/main.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/main.tf
@@ -34,7 +34,6 @@ provider "ocm" {
 }
 
 data "ocm_rosa_operator_roles" "operator_roles" {
-  cluster_id =var.cluster_id
   operator_role_prefix = var.operator_role_prefix
   account_role_prefix = var.account_role_prefix
 }

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/output.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/output.tf
@@ -1,0 +1,3 @@
+output operator_iam_roles {
+  value =  data.ocm_rosa_operator_roles.operator_roles.operator_iam_roles
+}

--- a/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/variables.tf
+++ b/examples/create_rosa_cluster/create_rosa_sts_cluster/operator_roles_and_oidc/variables.tf
@@ -7,6 +7,18 @@ variable operator_role_prefix {
     type = string
 }
 
+variable cluster_id {
+    type = string
+}
+
+variable oidc_endpoint_url {
+    type = string
+}
+
+variable oidc_thumbprint {
+    type = string
+}
+
 variable account_role_prefix {
     type = string
     default = ""

--- a/modules/aws_roles/README.md
+++ b/modules/aws_roles/README.md
@@ -161,7 +161,6 @@ operator_iam_roles = [
 
 ```
 data "ocm_rosa_operator_roles" "operator_roles" {
-  cluster_id = ocm_cluster_rosa_classic.rosa_sts_cluster.id
   operator_role_prefix = var.operator_role_prefix
   account_role_prefix = var.account_role_prefix
 }

--- a/modules/aws_roles/operator_roles/variables.tf
+++ b/modules/aws_roles/operator_roles/variables.tf
@@ -23,7 +23,6 @@ variable operator_role_properties {
         service_accounts = list(string)
         operator_name = string
         operator_namespace = string
-        role_arn = string
     })
 
 }

--- a/modules/aws_roles/variables.tf
+++ b/modules/aws_roles/variables.tf
@@ -23,7 +23,6 @@ variable operator_roles_properties {
         service_accounts = list(string)
         operator_name = string
         operator_namespace = string
-        role_arn = string
     }))
     validation {
       condition     = length(var.operator_roles_properties) == 6

--- a/provider/rosa_operator_roles_data_source.go
+++ b/provider/rosa_operator_roles_data_source.go
@@ -32,9 +32,8 @@ type RosaOperatorRolesDataSourceType struct {
 }
 
 type RosaOperatorRolesDataSource struct {
-	logger         logging.Logger
-	clustersClient *cmv1.ClustersClient
-	awsInquiries   *cmv1.AWSInquiriesClient
+	logger       logging.Logger
+	awsInquiries *cmv1.AWSInquiriesClient
 }
 
 const (
@@ -47,11 +46,6 @@ func (t *RosaOperatorRolesDataSourceType) GetSchema(ctx context.Context) (result
 	result = tfsdk.Schema{
 		Description: "List of rosa operator role for a specific cluster.",
 		Attributes: map[string]tfsdk.Attribute{
-			"cluster_id": {
-				Description: "Cluster id.",
-				Type:        types.StringType,
-				Required:    true,
-			},
 			"operator_role_prefix": {
 				Description: "Operator role prefix.",
 				Type:        types.StringType,
@@ -87,11 +81,6 @@ func (t *RosaOperatorRolesDataSourceType) itemAttributes() map[string]tfsdk.Attr
 			Type:        types.StringType,
 			Computed:    true,
 		},
-		"role_arn": {
-			Description: "AWS Role ARN",
-			Type:        types.StringType,
-			Computed:    true,
-		},
 		"role_name": {
 			Description: "policy name",
 			Type:        types.StringType,
@@ -118,14 +107,12 @@ func (t *RosaOperatorRolesDataSourceType) NewDataSource(ctx context.Context,
 	parent := p.(*Provider)
 
 	// Get the collection of clusters:
-	clustersClient := parent.connection.ClustersMgmt().V1().Clusters()
 	awsInquiries := parent.connection.ClustersMgmt().V1().AWSInquiries()
 
 	// Create the resource:
 	result = &RosaOperatorRolesDataSource{
-		logger:         parent.logger,
-		clustersClient: clustersClient,
-		awsInquiries:   awsInquiries,
+		logger:       parent.logger,
+		awsInquiries: awsInquiries,
 	}
 	return
 }
@@ -161,56 +148,39 @@ func (t *RosaOperatorRolesDataSource) Read(ctx context.Context, request tfsdk.Re
 		return true
 	})
 
-	get, err := t.clustersClient.Cluster(state.ClusterID.Value).Get().SendContext(ctx)
-	if err != nil {
-		response.Diagnostics.AddError(
-			"Can't find cluster",
-			fmt.Sprintf(
-				"Can't find cluster with identifier '%s': %v",
-				state.ClusterID.Value, err,
-			),
-		)
-		return
+	accountRolePrefix := DefaultAccountRolePrefix
+	if !state.AccountRolePrefix.Unknown && !state.AccountRolePrefix.Null && state.AccountRolePrefix.Value != "" {
+		accountRolePrefix = state.AccountRolePrefix.Value
 	}
-	object := get.Body()
-	sts, ok := object.AWS().GetSTS()
-	if ok {
-		accountRolePrefix := DefaultAccountRolePrefix
-		if !state.AccountRolePrefix.Unknown && !state.AccountRolePrefix.Null && state.AccountRolePrefix.Value != "" {
-			accountRolePrefix = state.AccountRolePrefix.Value
-		}
 
-		// TODO: use the sts.OperatorRolePrefix() if not empty
-		// There is a bug in the return value of sts.OperatorRolePrefix() - it's always empty string
-		for _, operatorRole := range sts.OperatorIAMRoles() {
-			r := OperatorIAMRole{
-				Name: types.String{
-					Value: operatorRole.Name(),
-				},
-				Namespace: types.String{
-					Value: operatorRole.Namespace(),
-				},
-				RoleARN: types.String{
-					Value: operatorRole.RoleARN(),
-				},
-				RoleName: types.String{
-					Value: getRoleName(state.OperatorRolePrefix.Value, operatorRole),
-				},
-				PolicyName: types.String{
-					Value: getPolicyName(accountRolePrefix, operatorRole.Namespace(), operatorRole.Name()),
-				},
-				ServiceAccounts: buildServiceAccountsArray(stsOperatorMap[operatorRole.Namespace()].ServiceAccounts(), operatorRole.Namespace()),
-			}
-			state.OperatorIAMRoles = append(state.OperatorIAMRoles, &r)
+	// TODO: use the sts.OperatorRolePrefix() if not empty
+	// There is a bug in the return value of sts.OperatorRolePrefix() - it's always empty string
+	for _, operatorRole := range stsOperatorMap {
+		r := OperatorIAMRole{
+			Name: types.String{
+				Value: operatorRole.Name(),
+			},
+			Namespace: types.String{
+				Value: operatorRole.Namespace(),
+			},
+			RoleName: types.String{
+				Value: getRoleName(state.OperatorRolePrefix.Value, operatorRole),
+			},
+			PolicyName: types.String{
+				Value: getPolicyName(accountRolePrefix, operatorRole.Namespace(), operatorRole.Name()),
+			},
+			ServiceAccounts: buildServiceAccountsArray(stsOperatorMap[operatorRole.Namespace()].ServiceAccounts(), operatorRole.Namespace()),
 		}
+		state.OperatorIAMRoles = append(state.OperatorIAMRoles, &r)
 	}
+
 	// Save the state:
 	diags = response.State.Set(ctx, state)
 	response.Diagnostics.Append(diags...)
 }
 
 // TODO: should be in a separate repo
-func getRoleName(rolePrefix string, operatorRole *cmv1.OperatorIAMRole) string {
+func getRoleName(rolePrefix string, operatorRole *cmv1.STSOperator) string {
 	role := fmt.Sprintf("%s-%s-%s", rolePrefix, operatorRole.Namespace(), operatorRole.Name())
 	if len(role) > 64 {
 		role = role[0:64]

--- a/provider/rosa_operator_roles_state.go
+++ b/provider/rosa_operator_roles_state.go
@@ -19,7 +19,6 @@ package provider
 import "github.com/hashicorp/terraform-plugin-framework/types"
 
 type RosaOperatorRolesState struct {
-	ClusterID          types.String       `tfsdk:"cluster_id"`
 	OperatorRolePrefix types.String       `tfsdk:"operator_role_prefix"`
 	AccountRolePrefix  types.String       `tfsdk:"account_role_prefix"`
 	OperatorIAMRoles   []*OperatorIAMRole `tfsdk:"operator_iam_roles"`
@@ -28,7 +27,6 @@ type RosaOperatorRolesState struct {
 type OperatorIAMRole struct {
 	Name            types.String `tfsdk:"operator_name"`
 	Namespace       types.String `tfsdk:"operator_namespace"`
-	RoleARN         types.String `tfsdk:"role_arn"`
 	RoleName        types.String `tfsdk:"role_name"`
 	PolicyName      types.String `tfsdk:"policy_name"`
 	ServiceAccounts types.List   `tfsdk:"service_accounts"`

--- a/subsystem/rosa_operator_roles_data_source_test.go
+++ b/subsystem/rosa_operator_roles_data_source_test.go
@@ -12,130 +12,6 @@ import (
 
 const (
 	// This is the cluster that will be returned by the server when asked to retrieve a cluster with ID 123
-	getClusterJson = `{
-	"kind": "",
-	"id": "123",
-	"name": "my-cluster",
-	"region": {
-		"id": "us-west-1"
-	},
-	"multi_az": true,
-	"api": {
-		"url": "https://my-api.example.com"
-	},
-	"console": {
-		"url": "https://my-console.example.com"
-	},
-	"nodes": {
-		"compute": 3,
-		"compute_machine_type": {
-			"id": "r5.xlarge"
-		}
-	},
-	"network": {
-		"machine_cidr": "10.0.0.0/16",
-		"service_cidr": "172.30.0.0/16",
-		"pod_cidr": "10.128.0.0/14",
-		"host_prefix": 23
-	},
-	"version": {
-		"id": "openshift-4.8.0"
-	},
-	"state": "ready",
-	"aws": {
-		"private_link": false,
-		"sts": {
-			"enabled": true,
-			"role_arn": "arn:aws:iam::account-id:role/TerraformAccount-Installer-Role",
-			"support_role_arn": "arn:aws:iam::account-id:role/TerraformAccount-Support-Role",
-			"oidc_endpoint_url": "https://oidc_endpoint_url",
-			"thumbprint": "111111",
-			"instance_iam_roles": {
-				"master_role_arn": "arn:aws:iam::account-id:role/TerraformAccount-ControlPlane-Role",
-				"worker_role_arn": "arn:aws:iam::account-id:role/TerraformAccount-Worker-Role"
-			},
-			"operator_role_prefix": "terraform-operator",
-			"operator_iam_roles": [
-				{
-					"id": "",
-					"name": "ebs-cloud-credentials",
-					"namespace": "openshift-cluster-csi-drivers",
-					"role_arn": "arn:aws:iam::765374464689:role/terrafom-operator-openshift-cluster-csi-drivers-ebs-cloud-creden",
-					"service_account": ""
-				},
-				{
-					"id": "",
-					"name": "cloud-credentials",
-					"namespace": "openshift-cloud-network-config-controller",
-					"role_arn": "arn:aws:iam::765374464689:role/terrafom-operator-openshift-cloud-network-config-controller-clou",
-					"service_account": ""
-				}
-			]
-		}
-	}
-}`
-	getClusterWithDefaultAccountPrefixJson = `{
-	"kind": "",
-	"id": "123",
-	"name": "my-cluster",
-	"region": {
-		"id": "us-west-1"
-	},
-	"multi_az": true,
-	"api": {
-		"url": "https://my-api.example.com"
-	},
-	"console": {
-		"url": "https://my-console.example.com"
-	},
-	"nodes": {
-		"compute": 3,
-		"compute_machine_type": {
-			"id": "r5.xlarge"
-		}
-	},
-	"network": {
-		"machine_cidr": "10.0.0.0/16",
-		"service_cidr": "172.30.0.0/16",
-		"pod_cidr": "10.128.0.0/14",
-		"host_prefix": 23
-	},
-	"version": {
-		"id": "openshift-4.8.0"
-	},
-	"state": "ready",
-	"aws": {
-		"private_link": false,
-		"sts": {
-			"enabled": true,
-			"role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Installer-Role",
-			"support_role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Support-Role",
-			"oidc_endpoint_url": "https://oidc_endpoint_url",
-			"thumbprint": "111111",
-			"instance_iam_roles": {
-				"master_role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-ControlPlane-Role",
-				"worker_role_arn": "arn:aws:iam::account-id:role/ManagedOpenShift-Worker-Role"
-			},
-			"operator_role_prefix": "terraform-operator",
-			"operator_iam_roles": [
-				{
-					"id": "",
-					"name": "ebs-cloud-credentials",
-					"namespace": "openshift-cluster-csi-drivers",
-					"role_arn": "arn:aws:iam::765374464689:role/terrafom-operator-openshift-cluster-csi-drivers-ebs-cloud-creden",
-					"service_account": ""
-				},
-				{
-					"id": "",
-					"name": "cloud-credentials",
-					"namespace": "openshift-cloud-network-config-controller",
-					"role_arn": "arn:aws:iam::765374464689:role/terrafom-operator-openshift-cloud-network-config-controller-clou",
-					"service_account": ""
-				}
-			]
-		}
-	}
-}`
 	getStsCredentialRequests = `{
 	"page": 1,
 	"size": 6,
@@ -181,16 +57,11 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/aws_inquiries/sts_credential_requests"),
 				RespondWithJSON(http.StatusOK, getStsCredentialRequests),
 			),
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
-				RespondWithJSON(http.StatusOK, getClusterJson),
-			),
 		)
 
 		// Run the apply command:
 		terraform.Source(`
 		  data "ocm_rosa_operator_roles" "operator_roles" {
-			  cluster_id = "123"
 			  operator_role_prefix = "terraform-operator"
 			  account_role_prefix = "TerraformAccountPrefix"
 		  }
@@ -202,13 +73,11 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 		//Expect(resource).To(MatchJQ(`.attributes.items | length`, 1))
 		Expect(resource).To(MatchJQ(`.attributes.operator_role_prefix`, "terraform-operator"))
 		Expect(resource).To(MatchJQ(`.attributes.account_role_prefix`, "TerraformAccountPrefix"))
-		Expect(resource).To(MatchJQ(`.attributes.cluster_id`, "123"))
 		Expect(resource).To(MatchJQ(`.attributes.operator_iam_roles | length`, 2))
 		compareResultOfRoles(resource, 0,
 			"ebs-cloud-credentials",
 			"openshift-cluster-csi-drivers",
 			"TerraformAccountPrefix-openshift-cluster-csi-drivers-ebs-cloud-c",
-			"arn:aws:iam::765374464689:role/terrafom-operator-openshift-cluster-csi-drivers-ebs-cloud-creden",
 			"terraform-operator-openshift-cluster-csi-drivers-ebs-cloud-crede",
 			2,
 			[]string{
@@ -221,7 +90,6 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 			"cloud-credentials",
 			"openshift-cloud-network-config-controller",
 			"TerraformAccountPrefix-openshift-cloud-network-config-controller",
-			"arn:aws:iam::765374464689:role/terrafom-operator-openshift-cloud-network-config-controller-clou",
 			"terraform-operator-openshift-cloud-network-config-controller-clo",
 			1,
 			[]string{"system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"},
@@ -235,16 +103,11 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/aws_inquiries/sts_credential_requests"),
 				RespondWithJSON(http.StatusOK, getStsCredentialRequests),
 			),
-			CombineHandlers(
-				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123"),
-				RespondWithJSON(http.StatusOK, getClusterWithDefaultAccountPrefixJson),
-			),
 		)
 
 		// Run the apply command:
 		terraform.Source(`
 		  data "ocm_rosa_operator_roles" "operator_roles" {
-			  cluster_id = "123"
 			  operator_role_prefix = "terraform-operator"
 		  }
 		`)
@@ -254,13 +117,11 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 		resource := terraform.Resource("ocm_rosa_operator_roles", "operator_roles")
 		//Expect(resource).To(MatchJQ(`.attributes.items | length`, 1))
 		Expect(resource).To(MatchJQ(`.attributes.operator_role_prefix`, "terraform-operator"))
-		Expect(resource).To(MatchJQ(`.attributes.cluster_id`, "123"))
 		Expect(resource).To(MatchJQ(`.attributes.operator_iam_roles | length`, 2))
 		compareResultOfRoles(resource, 0,
 			"ebs-cloud-credentials",
 			"openshift-cluster-csi-drivers",
 			"ManagedOpenShift-openshift-cluster-csi-drivers-ebs-cloud-credent",
-			"arn:aws:iam::765374464689:role/terrafom-operator-openshift-cluster-csi-drivers-ebs-cloud-creden",
 			"terraform-operator-openshift-cluster-csi-drivers-ebs-cloud-crede",
 			2,
 			[]string{
@@ -273,7 +134,6 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 			"cloud-credentials",
 			"openshift-cloud-network-config-controller",
 			"ManagedOpenShift-openshift-cloud-network-config-controller-cloud",
-			"arn:aws:iam::765374464689:role/terrafom-operator-openshift-cloud-network-config-controller-clou",
 			"terraform-operator-openshift-cloud-network-config-controller-clo",
 			1,
 			[]string{"system:serviceaccount:openshift-cloud-network-config-controller:cloud-network-config-controller"},
@@ -281,11 +141,10 @@ var _ = Describe("ROSA Operator IAM roles data source", func() {
 	})
 })
 
-func compareResultOfRoles(resource interface{}, index int, name, namespace, policyName, roleArn, roleName string, serviceAccountLen int, serviceAccounts []string) {
+func compareResultOfRoles(resource interface{}, index int, name, namespace, policyName, roleName string, serviceAccountLen int, serviceAccounts []string) {
 	operatorNameFmt := ".attributes.operator_iam_roles[%v].operator_name"
 	operatorNamespaceFmt := ".attributes.operator_iam_roles[%v].operator_namespace"
 	policyNameFmt := ".attributes.operator_iam_roles[%v].policy_name"
-	roleArnFmt := ".attributes.operator_iam_roles[%v].role_arn"
 	roleNameFmt := ".attributes.operator_iam_roles[%v].role_name"
 	serviceAccountLenFmt := ".attributes.operator_iam_roles[%v].service_accounts\t|\tlength "
 	serviceAccountFmt := ".attributes.operator_iam_roles[%v].service_accounts[%v]"
@@ -293,7 +152,6 @@ func compareResultOfRoles(resource interface{}, index int, name, namespace, poli
 	Expect(resource).To(MatchJQ(fmt.Sprintf(operatorNameFmt, index), name))
 	Expect(resource).To(MatchJQ(fmt.Sprintf(operatorNamespaceFmt, index), namespace))
 	Expect(resource).To(MatchJQ(fmt.Sprintf(policyNameFmt, index), policyName))
-	Expect(resource).To(MatchJQ(fmt.Sprintf(roleArnFmt, index), roleArn))
 	Expect(resource).To(MatchJQ(fmt.Sprintf(roleNameFmt, index), roleName))
 	Expect(resource).To(MatchJQ(fmt.Sprintf(serviceAccountLenFmt, index), serviceAccountLen))
 	for k, v := range serviceAccounts {


### PR DESCRIPTION
Most of the changes of that PR is separating the main.tf file of the cluster creation from the operator IAM roles creation.
There are several reasons for that change: 
1. BYO model - in order to support bringing your own operator IAM roles and OIDC provider, we would like to separate the creation of those resources from the cluster creation so that they won't be dependent on the cluster destroy.
2. The operator IAM roles and the OIDC provider should remain till the cluster finishes the uninstalling step - the operator IAM roles and OIDC provider cannot be deleted while the cluster is in uninstalling state. 


