### PR TITLE
Supporting default machine pool manipulation on update cluster

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/hashicorp/terraform-plugin-go v0.5.0
 	github.com/onsi/ginkgo/v2 v2.1.4
 	github.com/onsi/gomega v1.19.0
-	github.com/openshift-online/ocm-sdk-go v0.1.275
+	github.com/openshift-online/ocm-sdk-go v0.1.303
 )
 
 require (

--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -574,6 +574,9 @@ func (r *ClusterRosaClassicResource) Update(ctx context.Context, request tfsdk.U
 
 	// update the autoscaling enabled with the plan value (important for nil and false cases)
 	state.AutoScalingEnabled = plan.AutoScalingEnabled
+	// update the ComputeNodes with the plan value (important for nil and zero value cases)
+	state.ComputeNodes = plan.ComputeNodes
+
 	object := update.Body()
 
 	// Update the state:

--- a/provider/helpers.go
+++ b/provider/helpers.go
@@ -55,21 +55,3 @@ func shouldPatchString(state, plan types.String) (value string, ok bool) {
 	}
 	return
 }
-
-// shouldPatchString changed checks if the change between the given state and plan requires sending
-// a patch request to the server. If it does it returns the value to add to the patch.
-func shouldPatchBool(state, plan types.Bool) (value bool, ok bool) {
-	if plan.Unknown || plan.Null {
-		return
-	}
-	if state.Unknown || state.Null {
-		value = plan.Value
-		ok = true
-		return
-	}
-	if plan.Value != state.Value {
-		value = plan.Value
-		ok = true
-	}
-	return
-}

--- a/provider/helpers.go
+++ b/provider/helpers.go
@@ -55,3 +55,21 @@ func shouldPatchString(state, plan types.String) (value string, ok bool) {
 	}
 	return
 }
+
+// shouldPatchString changed checks if the change between the given state and plan requires sending
+// a patch request to the server. If it does it returns the value to add to the patch.
+func shouldPatchBool(state, plan types.Bool) (value bool, ok bool) {
+	if plan.Unknown || plan.Null {
+		return
+	}
+	if state.Unknown || state.Null {
+		value = plan.Value
+		ok = true
+		return
+	}
+	if plan.Value != state.Value {
+		value = plan.Value
+		ok = true
+	}
+	return
+}

--- a/provider/machine_pool_state.go
+++ b/provider/machine_pool_state.go
@@ -21,9 +21,12 @@ import (
 )
 
 type MachinePoolState struct {
-	Cluster     types.String `tfsdk:"cluster"`
-	ID          types.String `tfsdk:"id"`
-	MachineType types.String `tfsdk:"machine_type"`
-	Name        types.String `tfsdk:"name"`
-	Replicas    types.Int64  `tfsdk:"replicas"`
+	Cluster            types.String `tfsdk:"cluster"`
+	ID                 types.String `tfsdk:"id"`
+	MachineType        types.String `tfsdk:"machine_type"`
+	Name               types.String `tfsdk:"name"`
+	Replicas           types.Int64  `tfsdk:"replicas"`
+	AutoScalingEnabled types.Bool   `tfsdk:"autoscaling_enabled"`
+	MinReplicas        types.Int64  `tfsdk:"min_replicas"`
+	MaxReplicas        types.Int64  `tfsdk:"max_replicas"`
 }

--- a/subsystem/machine_pool_resource_test.go
+++ b/subsystem/machine_pool_resource_test.go
@@ -42,7 +42,7 @@ var _ = Describe("Machine pool creation", func() {
 		)
 	})
 
-	It("Can create machine pool", func() {
+	It("Can create machine pool with compute nodes", func() {
 		// Prepare the server:
 		server.AppendHandlers(
 			CombineHandlers(
@@ -83,4 +83,130 @@ var _ = Describe("Machine pool creation", func() {
 		Expect(resource).To(MatchJQ(".attributes.machine_type", "r5.xlarge"))
 		Expect(resource).To(MatchJQ(".attributes.replicas", 10.0))
 	})
+
+	It("Can create machine pool with autoscaling enabled and update to compute nodes", func() {
+		// Prepare the server:
+		server.AppendHandlers(
+			CombineHandlers(
+				VerifyRequest(
+					http.MethodPost,
+					"/api/clusters_mgmt/v1/clusters/123/machine_pools",
+				),
+				VerifyJSON(`{
+				  "kind": "MachinePool",
+				  "id": "my-pool",
+				  "autoscaling": {
+				  	"kind": "MachinePoolAutoscaling",
+				  	"max_replicas": 2,
+				  	"min_replicas": 0
+				  },
+				  "instance_type": "r5.xlarge"
+				}`),
+				RespondWithJSON(http.StatusOK, `{
+				  "id": "my-pool",
+				  "instance_type": "r5.xlarge",
+				  "autoscaling": {
+				    "max_replicas": 2,
+				    "min_replicas": 0	  
+				  }
+				}`),
+			),
+		)
+
+		// Run the apply command to create the machine pool resource:
+		terraform.Source(`
+		  resource "ocm_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+		    autoscaling_enabled = "true"
+		    min_replicas = "0"
+		    max_replicas = "2"
+		  }
+		`)
+		Expect(terraform.Apply()).To(BeZero())
+
+		// Check the state:
+		resource := terraform.Resource("ocm_machine_pool", "my_pool")
+		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
+		Expect(resource).To(MatchJQ(".attributes.id", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.name", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.machine_type", "r5.xlarge"))
+		Expect(resource).To(MatchJQ(".attributes.autoscaling_enabled", true))
+		Expect(resource).To(MatchJQ(".attributes.min_replicas", float64(0)))
+		Expect(resource).To(MatchJQ(".attributes.max_replicas", float64(2)))
+
+		server.AppendHandlers(
+			// First get is for the Read function
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool"),
+				RespondWithJSON(http.StatusOK, `
+				{
+				  "id": "my-pool",
+				  "kind": "MachinePool",
+				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
+				  "autoscaling": {
+				  	"kind": "MachinePoolAutoscaling",
+				  	"max_replicas": 2,
+				  	"min_replicas": 0
+				  },
+				  "instance_type": "r5.xlarge"
+				}`),
+			),
+			// Second get is for the Update function
+			CombineHandlers(
+				VerifyRequest(http.MethodGet, "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool"),
+				RespondWithJSON(http.StatusOK, `
+				{
+				  "id": "my-pool",
+				  "kind": "MachinePool",
+				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
+				  "autoscaling": {
+				  	"kind": "MachinePoolAutoscaling",
+				  	"max_replicas": 2,
+				  	"min_replicas": 0
+				  },
+				  "instance_type": "r5.xlarge"
+				}`),
+			),
+			CombineHandlers(
+				VerifyRequest(
+					http.MethodPatch,
+					"/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
+				),
+				VerifyJSON(`{
+				  "kind": "MachinePool",
+				  "id": "my-pool",
+				  "replicas": 10
+				}`),
+				RespondWithJSON(http.StatusOK, `
+				{
+				  "id": "my-pool",
+				  "href": "/api/clusters_mgmt/v1/clusters/123/machine_pools/my-pool",
+				  "kind": "MachinePool",
+				  "instance_type": "r5.xlarge",
+				  "replicas": 10
+				}`),
+			),
+		)
+		// Run the apply command to update the machine pool:
+		terraform.Source(`
+		  resource "ocm_machine_pool" "my_pool" {
+		    cluster      = "123"
+		    name         = "my-pool"
+		    machine_type = "r5.xlarge"
+		    replicas     = 10
+		  }
+		`)
+		Expect(terraform.Apply()).To(BeZero())
+
+		// Check the state:
+		resource = terraform.Resource("ocm_machine_pool", "my_pool")
+		Expect(resource).To(MatchJQ(".attributes.cluster", "123"))
+		Expect(resource).To(MatchJQ(".attributes.id", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.name", "my-pool"))
+		Expect(resource).To(MatchJQ(".attributes.machine_type", "r5.xlarge"))
+		Expect(resource).To(MatchJQ(".attributes.replicas", float64(10)))
+	})
+
 })


### PR DESCRIPTION
What - Adding a machine pool manipulation including auto scaler in the "update" method of cluster rosa resource
Why - Support changing the default machine pool of ROSA cluster with all the options: 
* compute nodes OR 
* autoscailing enabled with max replica and min replica 
