### PR TITLE
Block update cluster's attributes

### DIFF
--- a/provider/cluster_rosa_classic_resource.go
+++ b/provider/cluster_rosa_classic_resource.go
@@ -45,6 +45,7 @@ const (
 )
 
 type ClusterRosaClassicResourceType struct {
+	logger logging.Logger
 }
 
 type ClusterRosaClassicResource struct {
@@ -71,6 +72,9 @@ func (t *ClusterRosaClassicResourceType) GetSchema(ctx context.Context) (result 
 				Description: "Name of the cluster.",
 				Type:        types.StringType,
 				Required:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					ValueCannotBeChangedModifier(t.logger),
+				},
 			},
 			"cloud_region": {
 				Description: "Cloud region identifier, for example 'us-east-1'.",
@@ -89,7 +93,7 @@ func (t *ClusterRosaClassicResourceType) GetSchema(ctx context.Context) (result 
 				Optional: true,
 				Computed: true,
 				PlanModifiers: []tfsdk.AttributePlanModifier{
-					tfsdk.RequiresReplace(),
+					ValueCannotBeChangedModifier(t.logger),
 				},
 			},
 			"properties": {
@@ -110,6 +114,9 @@ func (t *ClusterRosaClassicResourceType) GetSchema(ctx context.Context) (result 
 				Type:        types.BoolType,
 				Optional:    true,
 				Computed:    true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					ValueCannotBeChangedModifier(t.logger),
+				},
 			},
 			"autoscaling_enabled": {
 				Description: "Enables autoscaling.",

--- a/provider/machine_pool_resource.go
+++ b/provider/machine_pool_resource.go
@@ -30,6 +30,7 @@ import (
 )
 
 type MachinePoolResourceType struct {
+	logger logging.Logger
 }
 
 type MachinePoolResource struct {
@@ -63,6 +64,9 @@ func (t *MachinePoolResourceType) GetSchema(ctx context.Context) (result tfsdk.S
 					"source to find the possible values.",
 				Type:     types.StringType,
 				Required: true,
+				PlanModifiers: []tfsdk.AttributePlanModifier{
+					ValueCannotBeChangedModifier(t.logger),
+				},
 			},
 			"replicas": {
 				Description: "The number of machines of the pool",

--- a/provider/provider.go
+++ b/provider/provider.go
@@ -210,10 +210,10 @@ func (p *Provider) GetResources(ctx context.Context) (result map[string]tfsdk.Re
 	diags diag.Diagnostics) {
 	result = map[string]tfsdk.ResourceType{
 		"ocm_cluster":              &ClusterResourceType{},
-		"ocm_cluster_rosa_classic": &ClusterRosaClassicResourceType{},
+		"ocm_cluster_rosa_classic": &ClusterRosaClassicResourceType{p.logger},
 		"ocm_group_membership":     &GroupMembershipResourceType{},
 		"ocm_identity_provider":    &IdentityProviderResourceType{},
-		"ocm_machine_pool":         &MachinePoolResourceType{},
+		"ocm_machine_pool":         &MachinePoolResourceType{p.logger},
 	}
 	return
 }

--- a/provider/value_cannot_be_changed_modifier.go
+++ b/provider/value_cannot_be_changed_modifier.go
@@ -1,0 +1,82 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/openshift-online/ocm-sdk-go/logging"
+)
+
+type valueCannotBeChangedModifier struct {
+	logger logging.Logger
+}
+
+func ValueCannotBeChangedModifier(logger logging.Logger) tfsdk.AttributePlanModifier {
+	return valueCannotBeChangedModifier{
+		logger: logger,
+	}
+}
+func (m valueCannotBeChangedModifier) Description(ctx context.Context) string {
+	return "The value cannot be changed after the resource was created."
+}
+
+func (m valueCannotBeChangedModifier) MarkdownDescription(ctx context.Context) string {
+	return m.Description(ctx)
+}
+
+func (m valueCannotBeChangedModifier) Modify(ctx context.Context, req tfsdk.ModifyAttributePlanRequest, resp *tfsdk.ModifyAttributePlanResponse) {
+
+	if req.AttributeConfig == nil || req.AttributeState == nil || req.AttributePlan == nil {
+		// shouldn't happen, but let's not panic if it does
+		return
+	}
+
+	if req.State.Raw.IsNull() {
+		// if we're creating the resource, no need to delete and
+		// recreate it
+		return
+	}
+
+	if req.Plan.Raw.IsNull() {
+		// if we're deleting the resource, no need to delete and
+		// recreate it
+		return
+	}
+
+	attrSchema, err := req.State.Schema.AttributeAtPath(req.AttributePath)
+	if err != nil && !errors.Is(err, errors.New("path leads to block, not an attribute")) {
+		resp.Diagnostics.AddAttributeError(req.AttributePath,
+			"Error finding attribute schema",
+			fmt.Sprintf("An unexpected error was encountered retrieving the schema for this attribute. This is always a bug in the provider.\n\nError: %s", err),
+		)
+		return
+	}
+
+	configRaw, err := req.AttributeConfig.ToTerraformValue(ctx)
+	if err != nil {
+		resp.Diagnostics.AddAttributeError(req.AttributePath,
+			"Error converting config value",
+			fmt.Sprintf("An unexpected error was encountered converting a %s to its equivalent Terraform representation. This is always a bug in the provider.\n\nError: %s", req.AttributeConfig.Type(ctx), err),
+		)
+		return
+	}
+
+	if configRaw == nil && attrSchema.Computed {
+		// if the config is null and the attribute is computed, this
+		// could be an out-of-band change, don't require blocking
+		return
+	}
+
+	if req.AttributeState.Equal(req.AttributePlan) {
+		m.logger.Debug(ctx, "attribute state and attribute plan have the same value")
+		return
+	}
+
+	// the attribute value was changes
+	m.logger.Debug(ctx, "attribute plan was changed")
+	resp.Diagnostics.AddAttributeError(req.AttributePath, "Value cannot be changed", "This attribute is blocked for updating")
+	return
+
+}


### PR DESCRIPTION
As part of the `terraform plan` command, we would like to block updates for several attributes.
The subsystem tests couldn't catch planModifier of attributes so this mechanism cannot be tested by UT or subsystem tests