### PR TITLE
add option to pass tags to apply for aws roles and identity providers

### DIFF
--- a/modules/aws_roles/cloud_identity_provider.tf
+++ b/modules/aws_roles/cloud_identity_provider.tf
@@ -6,9 +6,9 @@ resource "aws_iam_openid_connect_provider" "oidc_provider" {
     "sts.amazonaws.com"
   ]
 
-  tags = {
+  tags = merge(var.tags, {
     rosa_cluster_id = var.cluster_id
-  }
+  })
 
   thumbprint_list = [var.rh_oidc_provider_thumbprint]
 }

--- a/modules/aws_roles/main.tf
+++ b/modules/aws_roles/main.tf
@@ -7,13 +7,14 @@ terraform {
   }
 }
 
-module rosa_operator_roles {
-    source = "./operator_roles"
-    count = 6
+module "rosa_operator_roles" {
+  source = "./operator_roles"
+  count  = 6
 
-    cluster_id = var.cluster_id
-    rh_oidc_provider_url = var.rh_oidc_provider_url
-    rh_oidc_provider_thumbprint = var.rh_oidc_provider_thumbprint
-    operator_role_properties = var.operator_roles_properties[count.index]
+  cluster_id                  = var.cluster_id
+  rh_oidc_provider_url        = var.rh_oidc_provider_url
+  rh_oidc_provider_thumbprint = var.rh_oidc_provider_thumbprint
+  operator_role_properties    = var.operator_roles_properties[count.index]
+  tags                        = var.tags
 }
 

--- a/modules/aws_roles/operator_roles/operator_role_resource.tf
+++ b/modules/aws_roles/operator_roles/operator_role_resource.tf
@@ -9,9 +9,9 @@ resource "aws_iam_role" "operator_role" {
         Action = "sts:AssumeRoleWithWebIdentity"
         Effect = "Allow"
         Condition = {
-            StringEquals = {
-                "${var.rh_oidc_provider_url}:sub" = var.operator_role_properties.service_accounts
-            }
+          StringEquals = {
+            "${var.rh_oidc_provider_url}:sub" = var.operator_role_properties.service_accounts
+          }
         }
         Principal = {
           Federated = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/${var.rh_oidc_provider_url}"
@@ -20,16 +20,16 @@ resource "aws_iam_role" "operator_role" {
     ]
   })
 
-  tags = {
-    red-hat-managed = true
-    rosa_cluster_id = var.cluster_id
+  tags = merge(var.tags, {
+    red-hat-managed    = true
+    rosa_cluster_id    = var.cluster_id
     operator_namespace = var.operator_role_properties.operator_namespace
-    operator_name = var.operator_role_properties.operator_name
-  }
+    operator_name      = var.operator_role_properties.operator_name
+  })
 }
 
 resource "aws_iam_role_policy_attachment" "operator_role_policy_attachment" {
-  role = aws_iam_role.operator_role.name
+  role       = aws_iam_role.operator_role.name
   policy_arn = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:policy/${var.operator_role_properties.policy_name}"
 }
 

--- a/modules/aws_roles/operator_roles/variables.tf
+++ b/modules/aws_roles/operator_roles/variables.tf
@@ -1,28 +1,34 @@
-variable cluster_id {
-    description = "cluster ID"
-    type = string
+variable "cluster_id" {
+  description = "cluster ID"
+  type        = string
 }
 
-variable rh_oidc_provider_url {
-    description = "oidc provider url"
-    type = string
-    default = "rh-oidc.s3.us-east-1.amazonaws.com"
+variable "rh_oidc_provider_url" {
+  description = "oidc provider url"
+  type        = string
+  default     = "rh-oidc.s3.us-east-1.amazonaws.com"
 }
 
-variable rh_oidc_provider_thumbprint {
-    description = "Thumbprint for the variable `rh_oidc_provider_url`"
-    type = string
-    default = "917e732d330f9a12404f73d8bea36948b929dffc"
+variable "rh_oidc_provider_thumbprint" {
+  description = "Thumbprint for the variable `rh_oidc_provider_url`"
+  type        = string
+  default     = "917e732d330f9a12404f73d8bea36948b929dffc"
 }
 
-variable operator_role_properties {
-    description = ""
-    type = object({
-        role_name = string
-        policy_name = string
-        service_accounts = list(string)
-        operator_name = string
-        operator_namespace = string
-    })
+variable "operator_role_properties" {
+  description = ""
+  type = object({
+    role_name          = string
+    policy_name        = string
+    service_accounts   = list(string)
+    operator_name      = string
+    operator_namespace = string
+  })
 
 }
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
+}
+

--- a/modules/aws_roles/variables.tf
+++ b/modules/aws_roles/variables.tf
@@ -1,32 +1,38 @@
-variable cluster_id {
-    description = "cluster ID"
-    type = string
+variable "cluster_id" {
+  description = "cluster ID"
+  type        = string
 }
 
-variable rh_oidc_provider_url {
-    description = "oidc provider url"
-    type = string
-    default = "rh-oidc.s3.us-east-1.amazonaws.com"
+variable "rh_oidc_provider_url" {
+  description = "oidc provider url"
+  type        = string
+  default     = "rh-oidc.s3.us-east-1.amazonaws.com"
 }
 
-variable rh_oidc_provider_thumbprint {
-    description = "Thumbprint for https://rh-oidc.s3.us-east-1.amazonaws.com"
-    type = string
-    default = "917e732d330f9a12404f73d8bea36948b929dffc"
+variable "rh_oidc_provider_thumbprint" {
+  description = "Thumbprint for https://rh-oidc.s3.us-east-1.amazonaws.com"
+  type        = string
+  default     = "917e732d330f9a12404f73d8bea36948b929dffc"
 }
 
-variable operator_roles_properties {
-    description = "List of ROSA Operator IAM Roles"
-    type = list(object({
-        role_name = string
-        policy_name = string
-        service_accounts = list(string)
-        operator_name = string
-        operator_namespace = string
-    }))
-    validation {
-      condition     = length(var.operator_roles_properties) == 6
-      error_message = "The list of operator roles should contains 6 elements"
-    }
+variable "operator_roles_properties" {
+  description = "List of ROSA Operator IAM Roles"
+  type = list(object({
+    role_name          = string
+    policy_name        = string
+    service_accounts   = list(string)
+    operator_name      = string
+    operator_namespace = string
+  }))
+  validation {
+    condition     = length(var.operator_roles_properties) == 6
+    error_message = "The list of operator roles should contains 6 elements"
+  }
 
+}
+
+variable "tags" {
+  description = "List of aws resource tags to apply."
+  type        = map(string)
+  default     = null
 }


### PR DESCRIPTION
Add variable `tags` to terraform module to apply to iam role and identity providers created.