### PR TITLE
Fix Terraform module link to openshift-online

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ module sts_roles {
 ## Documentation
 
 The reference documentation of the provider is available in the Terraform
-[registry](https://registry.terraform.io/providers/rh-mobb/ocm/latest/docs).
+[registry](https://registry.terraform.io/providers/openshift-online/ocm/latest/docs).
 
 ## Examples
 


### PR DESCRIPTION
I could be wrong but it looks like the README in this module is pointing to a different module, which seems to be out of date.